### PR TITLE
plotting spectra from multiple surveys

### DIFF
--- a/Galaxy_survey_lib_with_HST.ipynb
+++ b/Galaxy_survey_lib_with_HST.ipynb
@@ -1,0 +1,704 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import numpy as np\n",
+    "import astropy\n",
+    "from astropy.io import ascii\n",
+    "from astropy.table import Table\n",
+    "from astropy.io import fits\n",
+    "import cosmo\n",
+    "import matplotlib.pyplot as plt\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "from astropy import units as u\n",
+    "from astropy.table import Column"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook matches galaxies from various surveys to the DEIMOS survey for a more comprehensive data catalogue.\n",
+    "\n",
+    "All data tables come from \"galaxy_inputs\" folder."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#DEIMOS catalogue\n",
+    "F = np.genfromtxt('galaxy_inputs/cosmos_example_hostlib.txt', skip_header = 1)\n",
+    "names = ['IGNORE','GALID', 'RA_GAL', 'DEC_GAL', 'ZTRUE', 'ZERR', 'ZPHOT', 'ZPHOTERR', 'logsfr', 'logmass', 'logssfr', 'hstj_obs',  'hsth_obs', 'n0_Sersic', 'a0_Sersic', 'b0_Sersic', 'a_rot', 'eazy_coeff00', 'eazy_coeff01', 'eazy_coeff02', 'eazy_coeff03', 'eazy_coeff04', 'eazy_coeff05', 'eazy_coeff06', 'eazy_coeff07', 'eazy_coeff08', 'eazy_coeff09', 'eazy_coeff10', 'eazy_coeff11', 'eazy_coeff12']\n",
+    "T = Table(names = ('IGNORE','GALID', 'RA_GAL', 'DEC_GAL', 'ZTRUE', 'ZERR', 'ZPHOT', 'ZPHOTERR', 'logsfr', 'logmass', 'logssfr', 'hstj_obs',  'hsth_obs', 'n0_Sersic', 'a0_Sersic', 'b0_Sersic', 'a_rot', 'eazy_coeff00', 'eazy_coeff01', 'eazy_coeff02', 'eazy_coeff03', 'eazy_coeff04', 'eazy_coeff05', 'eazy_coeff06', 'eazy_coeff07', 'eazy_coeff08', 'eazy_coeff09', 'eazy_coeff10', 'eazy_coeff11', 'eazy_coeff12'))\n",
+    "for row in F:\n",
+    "    T.add_row(row)\n",
+    "    \n",
+    "r = list(T[1])\n",
+    "for x in range (0, len(r)):\n",
+    "    if isinstance(r[x], str)==True:\n",
+    "        T.remove_column(names[x])\n",
+    "T.remove_column(\"IGNORE\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/leahvazsonyi/astronomy/Galaxylib/cosmo.py:192: RuntimeWarning: overflow encountered in sinh\n",
+      "  z = ( A * sinh( B ) )**(-2/3.) - 1\n"
+     ]
+    }
+   ],
+   "source": [
+    "#G10 catalogue\n",
+    "F_2 = fits.open(\"galaxy_inputs/G10CosmosCatv05/G10COSMOSCatv05.fits\")\n",
+    "T_2 = Table.read(F_2)\n",
+    "add1 = T_2['filename_ZCOS']\n",
+    "add2 = T_2['SPEC_FILENAME']\n",
+    "names = list(T_2.columns)\n",
+    "r = list(T_2[1])\n",
+    "for x in range (0, len(r)):\n",
+    "    if isinstance(r[x], str)==True:\n",
+    "        T_2.remove_column(names[x])\n",
+    "T_2[\"Z_06\"] = (-1)*(cosmo.zfromt(T_2[\"Z_06\"]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#matching coordinates\n",
+    "c = SkyCoord(ra=T[\"RA_GAL\"]*u.degree, dec=T[\"DEC_GAL\"]*u.degree, distance = T[\"ZTRUE\"])\n",
+    "catalog = SkyCoord(ra=T_2[\"RA_06\"]*u.degree, dec=T_2[\"DEC_06\"]*u.degree, distance = T_2[\"Z_06\"])\n",
+    "idx, d2d, d3d = c.match_to_catalog_3d(catalog)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "matches = catalog[idx]\n",
+    "matches_i = []\n",
+    "T_2_match = T_2[idx]\n",
+    "ids = []\n",
+    "#confirming that all matches are within 1 arcsec of the original catalogue galaxy\n",
+    "for a in range (0, len(T[\"RA_GAL\"])):\n",
+    "    x = T[\"RA_GAL\"][a]\n",
+    "    y = T_2_match[\"RA_06\"][a]\n",
+    "    if x-y <= 0.000278:\n",
+    "        w = T[\"DEC_GAL\"][a]\n",
+    "        z = T_2_match[\"DEC_06\"][a]\n",
+    "        if w-z <= 0.000278:\n",
+    "            matches_i.append(idx[a])\n",
+    "            ids.append(T[\"GALID\"][a])\n",
+    "T_2_m = T_2[matches_i] #Table of galaxies from G10 catalogue which match DEIMOS catalogue\n",
+    "add1_m = add1[matches_i]\n",
+    "add2_m = add2[matches_i]\n",
+    "g = Column(ids, name = \"GALID2\")\n",
+    "T_2_m.add_column(g)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#vUDS catalogue\n",
+    "F_3 = ascii.read(\"galaxy_inputs/cesam_vuds_spectra_dr1_cosmos_catalog_1566516152.csv\")\n",
+    "\n",
+    "T_3 = Table(F_3)\n",
+    "names = list(T_3.columns)\n",
+    "r = list(T_3[1])\n",
+    "for x in range (0, len(r)):\n",
+    "    if isinstance(r[x], str)==True:\n",
+    "        T_3.remove_column(names[x])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.coordinates import SkyCoord\n",
+    "from astropy import units as u\n",
+    "c = SkyCoord(ra=T[\"RA_GAL\"]*u.degree, dec=T[\"DEC_GAL\"]*u.degree, distance = T[\"ZTRUE\"])\n",
+    "catalog = SkyCoord(ra=T_3[\"alpha\"]*u.degree, dec=T_3[\"delta\"]*u.degree, distance = T_3[\"z_spec\"])\n",
+    "idx, d2d, d3d = c.match_to_catalog_3d(catalog)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "matches1 = catalog[idx]\n",
+    "\n",
+    "T_3_match = T_3[idx]\n",
+    "ids = []\n",
+    "matches_i = []\n",
+    "for a in range (0, len(T[\"RA_GAL\"])):\n",
+    "    x = T[\"RA_GAL\"][a]\n",
+    "    y = T_3_match[\"alpha\"][a]\n",
+    "    if x-y <= 0.000278:\n",
+    "        w = T[\"DEC_GAL\"][a]\n",
+    "        z = T_3_match[\"delta\"][a]\n",
+    "        if w-z <= 0.000278:\n",
+    "            matches_i.append(idx[a])\n",
+    "            ids.append(T[\"GALID\"][a])\n",
+    "T_3_m = T_3[matches_i]\n",
+    "f = Column(ids, name = \"GALID3\")\n",
+    "T_3_m.add_column(f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#zCosmos Catalogue\n",
+    "F_4 = fits.open(\"galaxy_inputs/zCOSMOS_VIMOS_BRIGHT_DR3_CATALOGUE.fits\")\n",
+    "T_4 = Table.read(F_4)\n",
+    "names = list(T_4.columns)\n",
+    "r = list(T_4[1])\n",
+    "for x in range (0, len(r)):\n",
+    "    if isinstance(r[x], str)==True:\n",
+    "        T_4.remove_column(names[x])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.coordinates import SkyCoord\n",
+    "from astropy import units as u\n",
+    "c = SkyCoord(ra=T[\"RA_GAL\"]*u.degree, dec=T[\"DEC_GAL\"]*u.degree, distance = T[\"ZTRUE\"])\n",
+    "catalog = SkyCoord(ra=T_4[\"RAJ2000\"], dec=T_4[\"DEJ2000\"], distance = T_4[\"REDSHIFT\"])\n",
+    "idx, d2d, d3d = c.match_to_catalog_3d(catalog)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "matches1 = catalog[idx]\n",
+    "\n",
+    "T_4_match = T_4[idx]\n",
+    "ids = []\n",
+    "matches_i = []\n",
+    "for a in range (0, len(T[\"RA_GAL\"])):\n",
+    "    x = T[\"RA_GAL\"][a]\n",
+    "    y = T_4_match[\"RAJ2000\"][a]\n",
+    "    if x-y <= 0.000278:\n",
+    "        w = T[\"DEC_GAL\"][a]\n",
+    "        z = T_4_match[\"DEJ2000\"][a]\n",
+    "        if w-z <= 0.000278:\n",
+    "            matches_i.append(idx[a])\n",
+    "            ids.append(T[\"GALID\"][a])\n",
+    "T_4_m = T_4[matches_i]\n",
+    "h = Column(ids, name = \"GALID4\")\n",
+    "T_4_m.add_column(h)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "OSError",
+     "evalue": "File exists: gal_lib_mod.fits",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mOSError\u001b[0m                                   Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-12-8825fc73a250>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     40\u001b[0m \u001b[0mrow1f\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mColumn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mrow1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mname\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m'filename_ZCOS'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     41\u001b[0m \u001b[0mrow2f\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mColumn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mrow2\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mname\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m'SPEC_FILENAME'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 42\u001b[0;31m \u001b[0mT_final\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwrite\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"gal_lib_mod.fits\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mformat\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m\"fits\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/anaconda3/lib/python3.7/site-packages/astropy/table/table.py\u001b[0m in \u001b[0;36mwrite\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m   2592\u001b[0m         \u001b[0mserialize_method\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mkwargs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpop\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'serialize_method'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2593\u001b[0m         \u001b[0;32mwith\u001b[0m \u001b[0mserialize_method_as\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mserialize_method\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2594\u001b[0;31m             \u001b[0mio_registry\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwrite\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2595\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2596\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mcopy\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcopy_data\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.7/site-packages/astropy/io/registry.py\u001b[0m in \u001b[0;36mwrite\u001b[0;34m(data, format, *args, **kwargs)\u001b[0m\n\u001b[1;32m    558\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    559\u001b[0m     \u001b[0mwriter\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mget_writer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__class__\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 560\u001b[0;31m     \u001b[0mwriter\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    561\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    562\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/lib/python3.7/site-packages/astropy/io/fits/connect.py\u001b[0m in \u001b[0;36mwrite_table_fits\u001b[0;34m(input, output, overwrite)\u001b[0m\n\u001b[1;32m    393\u001b[0m             \u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mremove\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    394\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 395\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mOSError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"File exists: {0}\"\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    396\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    397\u001b[0m     \u001b[0mtable_hdu\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwriteto\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mOSError\u001b[0m: File exists: gal_lib_mod.fits"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "'''Builds final catalogue by combining all of the matched tables into one larger table.\n",
+    "If there is no data for a specific cell, it will be filled with a 0'''\n",
+    "names = (list(T.columns) + list(T_2_m.columns) + list(T_3_m.columns) + list(T_4_m.columns))\n",
+    "\n",
+    "T_final = Table(names = (list(T.columns) + list(T_2_m.columns) + list(T_3_m.columns) + list(T_4_m.columns)))\n",
+    "row1 = []\n",
+    "row2 = []\n",
+    "for x in range(0, len(T[\"GALID\"])):\n",
+    "    ID = T[\"GALID\"][x]\n",
+    "    r1 = list(T[x])\n",
+    "    if ID in T_2_m[\"GALID2\"]:\n",
+    "        l = list(T_2_m[\"GALID2\"])\n",
+    "        ind = l.index(ID)\n",
+    "        r2 = list(T_2_m[ind])\n",
+    "        row1.append(add1_m[ind])\n",
+    "        row2.append(add2_m[ind])\n",
+    "    else:\n",
+    "        y = len(list(T_2_m[1]))\n",
+    "        r2 = list(y*\"0\")\n",
+    "        row1.append(0)\n",
+    "        row2.append(0)\n",
+    "    if ID in T_3_m[\"GALID3\"]:\n",
+    "        l = list(T_3_m[\"GALID3\"])\n",
+    "        ind = l.index(ID)\n",
+    "        r3 = list(T_3_m[ind])\n",
+    "    else:\n",
+    "        y = len(list(T_3_m[1]))\n",
+    "        r3 = list(y*\"0\")\n",
+    "    if ID in T_4_m[\"GALID4\"]:\n",
+    "        l = list(T_4_m[\"GALID4\"])\n",
+    "        ind = l.index(ID)\n",
+    "        r4 = list(T_4_m[ind])\n",
+    "    else:\n",
+    "        y = len(list(T_4[1]))+1\n",
+    "        r4 = list(y*\"0\")\n",
+    "    row = np.array(r1 + r2 + r3 + r4, dtype = object)\n",
+    "    T_final.add_row(row)\n",
+    "\n",
+    "row1f = Column(row1, name = 'filename_ZCOS')\n",
+    "row2f = Column(row2, name = 'SPEC_FILENAME')\n",
+    "T_final.write(\"gal_lib_mod.fits\", format = \"fits\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "'''Matches from HST catalogue'''\n",
+    "F = np.genfromtxt('galaxy_inputs/3dhst_master.phot.v4.1.cat', skip_header = 41202)\n",
+    "T_HST = Table(names = ('id', 'field', 'ra', 'dec', 'x', 'y', 'z_spec', 'z_peak', 'faper_F140W', 'eaper_F140W', 'faper_F160W', 'eaper_F160W', 'f_F606W', 'e_F606W', 'f_F814W', 'e_F814W', 'f_F125W', 'e_F125W', 'f_F140W', 'e_F140W', 'f_F160W', 'e_F160W', 'tot_cor', 'kron_radius', 'a_image', 'b_image', 'flux_radius', 'fwhm_image', 'flags', 'f140w_flag', 'star_flag', 'use_phot', 'near_star', 'nexp_f125w', 'nexp_f140w', 'nexp_f160w', 'lmass', 'Av'))\n",
+    "count = 0\n",
+    "for row in F:\n",
+    "    T_HST.add_row(row)\n",
+    "    count = count + 1\n",
+    "    if count > 33882:\n",
+    "        break"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "T_HST_tot = Table(names = (\"GALID\", \"RA_GAL\", \"DEC_GAL\", \"ZTRUE\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#cosmos-02\n",
+    "T_HST_tot.add_row([T_final[16][\"GALID\"], T_final[16][\"RA_GAL\"], T_final[16][\"DEC_GAL\"], T_final[16][\"ZTRUE\"]])\n",
+    "T_HST_tot.add_row([T_final[19][\"GALID\"], T_final[19][\"RA_GAL\"], T_final[19][\"DEC_GAL\"], T_final[19][\"ZTRUE\"]])\n",
+    "T_HST_tot.add_row([T_final[18][\"GALID\"], T_final[18][\"RA_GAL\"], T_final[18][\"DEC_GAL\"], T_final[18][\"ZTRUE\"]])\n",
+    "names = Column(data =[\"cosmos-02\", \"cosmos-02\", \"cosmos-02\"], name = (\"FOLDER\"))\n",
+    "T_HST_tot.add_column(names)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#cosmos-03\n",
+    "T_HST_tot.add_row([T_final[1][\"GALID\"], T_final[1][\"RA_GAL\"], T_final[1][\"DEC_GAL\"], T_final[1][\"ZTRUE\"], \"cosmos-03\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#cosmos-04\n",
+    "T_HST_tot.add_row([T_final[28][\"GALID\"], T_final[28][\"RA_GAL\"], T_final[28][\"DEC_GAL\"], T_final[28][\"ZTRUE\"], \"cosmos-04\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#cosmos-06\n",
+    "T_HST_tot.add_row([T_final[6][\"GALID\"], T_final[6][\"RA_GAL\"], T_final[6][\"DEC_GAL\"], T_final[6][\"ZTRUE\"], \"cosmos-06\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#cosmos-07\n",
+    "T_HST_tot.add_row([T_final[4][\"GALID\"], T_final[4][\"RA_GAL\"], T_final[4][\"DEC_GAL\"], T_final[4][\"ZTRUE\"], \"cosmos-07\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#cosmos-11\n",
+    "T_HST_tot.add_row([T_final[17][\"GALID\"], T_final[17][\"RA_GAL\"], T_final[17][\"DEC_GAL\"], T_final[17][\"ZTRUE\"], \"cosmos-11\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#cosmos-12\n",
+    "T_HST_tot.add_row([T_final[9][\"GALID\"], T_final[9][\"RA_GAL\"], T_final[9][\"DEC_GAL\"], T_final[9][\"ZTRUE\"], \"cosmos-12\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#cosmos-13\n",
+    "T_HST_tot.add_row([T_final[7][\"GALID\"], T_final[7][\"RA_GAL\"], T_final[7][\"DEC_GAL\"], T_final[7][\"ZTRUE\"], \"cosmos-13\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#cosmos-14\n",
+    "T_HST_tot.add_row([T_final[8][\"GALID\"], T_final[8][\"RA_GAL\"], T_final[8][\"DEC_GAL\"], T_final[8][\"ZTRUE\"], \"cosmos-14\"])\n",
+    "T_HST_tot.add_row([T_final[12][\"GALID\"], T_final[12][\"RA_GAL\"], T_final[12][\"DEC_GAL\"], T_final[12][\"ZTRUE\"], \"cosmos-14\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#cosmos-15\n",
+    "T_HST_tot.add_row([T_final[14][\"GALID\"], T_final[14][\"RA_GAL\"], T_final[14][\"DEC_GAL\"], T_final[14][\"ZTRUE\"], \"cosmos-15\"])\n",
+    "T_HST_tot.add_row([T_final[21][\"GALID\"], T_final[21][\"RA_GAL\"], T_final[21][\"DEC_GAL\"], T_final[21][\"ZTRUE\"], \"cosmos-15\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#cosmos-18\n",
+    "T_HST_tot.add_row([T_final[22][\"GALID\"], T_final[22][\"RA_GAL\"], T_final[22][\"DEC_GAL\"], T_final[22][\"ZTRUE\"], \"cosmos-18\"])\n",
+    "T_HST_tot.add_row([T_final[25][\"GALID\"], T_final[25][\"RA_GAL\"], T_final[25][\"DEC_GAL\"], T_final[25][\"ZTRUE\"], \"cosmos-18\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#cosmos-19\n",
+    "T_HST_tot.add_row([T_final[26][\"GALID\"], T_final[26][\"RA_GAL\"], T_final[26][\"DEC_GAL\"], T_final[26][\"ZTRUE\"], \"cosmos-19\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "#cosmos-24\n",
+    "T_HST_tot.add_row([T_final[11][\"GALID\"], T_final[11][\"RA_GAL\"], T_final[11][\"DEC_GAL\"], T_final[11][\"ZTRUE\"], \"cosmos-24\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#cosmos-25\n",
+    "T_HST_tot.add_row([T_final[13][\"GALID\"], T_final[13][\"RA_GAL\"], T_final[13][\"DEC_GAL\"], T_final[13][\"ZTRUE\"], \"cosmos-25\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#cosmos-26\n",
+    "T_HST_tot.add_row([T_final[3][\"GALID\"], T_final[3][\"RA_GAL\"], T_final[3][\"DEC_GAL\"], T_final[3][\"ZTRUE\"], \"cosmos-26\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#cosmos-27\n",
+    "T_HST_tot.add_row([T_final[5][\"GALID\"], T_final[5][\"RA_GAL\"], T_final[5][\"DEC_GAL\"], T_final[5][\"ZTRUE\"], \"cosmos-27\"])\n",
+    "T_HST_tot.add_row([T_final[2][\"GALID\"], T_final[2][\"RA_GAL\"], T_final[2][\"DEC_GAL\"], T_final[2][\"ZTRUE\"], \"cosmos-27\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = SkyCoord(ra=T_HST_tot[\"RA_GAL\"]*u.degree, dec=T_HST_tot[\"DEC_GAL\"]*u.degree)\n",
+    "catalog = SkyCoord(ra=T_HST[\"ra\"]*u.degree, dec=T_HST[\"dec\"]*u.degree)\n",
+    "idx, d2d, d3d = c.match_to_catalog_3d(catalog)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "matches1 = catalog[idx]\n",
+    "\n",
+    "T_HST_match = T_HST[idx]\n",
+    "ids = []\n",
+    "matches_i = []\n",
+    "for a in range (0, len(T_HST_tot[\"RA_GAL\"])):\n",
+    "    x = T_HST_tot[\"RA_GAL\"][a]\n",
+    "    y = T_HST_match[\"ra\"][a]\n",
+    "    if x-y <= 0.000278:\n",
+    "        w = T_HST_tot[\"DEC_GAL\"][a]\n",
+    "        z = T_HST_match[\"dec\"][a]\n",
+    "        if w-z <= 0.000278:\n",
+    "            matches_i.append(idx[a])\n",
+    "            ids.append(T_HST_tot[\"GALID\"][a])\n",
+    "T_HST_m = T_HST[matches_i]\n",
+    "h = Column(T_HST_m[\"id\"])\n",
+    "\n",
+    "T_HST_tot.add_column(h)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ascii.write(T_HST_tot, \"cosmos_match.dat\", overwrite = True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Table with vUDS and DEIMOS filenames, DEIMOS galaxy ID, RA, Dec, and redshift\n",
+    "T_short = Table()\n",
+    "T_short.add_column(T_final[\"GALID\"])\n",
+    "T_short.add_column(T_final[\"ZTRUE\"])\n",
+    "T_short.add_column(T_final[\"CATAID\"])\n",
+    "T_short.add_column(row1f)\n",
+    "T_short.add_column(row2f)\n",
+    "T_short.add_column(T_final[\"vuds_ident\"])\n",
+    "filenames = ['sc_5101466323_F51P008_join_A_78_1_atm_clean.fits', 'sc_5101236893_F51P006_join_A_75_1_atm_clean.fits', 0, 'sc_5101243705_F51P006_join_A_10_1_atm_clean.fits', 0, 'sc_5110445455_F51P008_join_A_41_2_atm_clean.fits', 'sc_5101245800_F51P006_join_A_19_1_atm_clean.fits', 0, 'sc_5101236942_F51P006_join_A_32_1_atm_clean.fits', 0, 0, 'sc_5101455396_F51P008_join_A_36_1_atm_clean.fits', 'sc_511233860_F51P007_join_A_125_1_atm_clean.fits', 0, 0, 0, 'sc_5100996068_F51P006_join_A_30_2_atm_clean.fits', 0, 0, 0, 0, 0, 0, 0, 0, 0, 'sc_5101002365_F51P006_join_A_76_1_atm_clean.fits', 0, 0]\n",
+    "filenames2 = ['sc_5101466323_F51P008_join_A_78_1_noise.fits', 'sc_5101236893_F51P006_join_A_75_1_noise.fits', 0, 'sc_5101243705_F51P006_join_A_10_1_noise.fits', 0, 'sc_5110445455_F51P008_join_A_41_2_noise.fits', 'sc_5101245800_F51P006_join_A_19_1_noise.fits', 0, 'sc_5101236942_F51P006_join_A_32_1_noise.fits', 0, 0, 'sc_5101455396_F51P008_join_A_36_1_noise.fits', 'sc_511233860_F51P007_join_A_125_1_noise.fits', 0, 0, 0, 'sc_5100996068_F51P006_join_A_30_2_noise.fits', 0, 0, 0, 0, 0, 0, 0, 0, 0, 'sc_5101002365_F51P006_join_A_76_1_noise.fits', 0, 0]\n",
+    "filenames3 = ['cosmos_example_spec1d_206109.fits', 'cosmos_example_spec1d_215166.fits', 'cosmos_example_spec1d_218365.fits', 'cosmos_example_spec1d_211373.fits', 'cosmos_example_spec1d_226295.fits', 'cosmos_example_spec1d_217263.fits', 'cosmos_example_spec1d_204489.fits', 'cosmos_example_spec1d_205925.fits', 'cosmos_example_spec1d_201957.fits', 'cosmos_example_spec1d_209459.fits', 'cosmos_example_spec1d_233753.fits', 'cosmos_example_spec1d_214249.fits', 'cosmos_example_spec1d_201535.fits', 'cosmos_example_spec1d_219723.fits', 'cosmos_example_spec1d_223627.fits', 'cosmos_example_spec1d_205108.fits', 'cosmos_example_spec1d_205342.fits', 'cosmos_example_spec1d_227457.fits', 'cosmos_example_spec1d_202422.fits', 'cosmos_example_spec1d_202800.fits', 'cosmos_example_spec1d_201351.fits', 'cosmos_example_spec1d_224092.fits', 'cosmos_example_spec1d_217941.fits', 'cosmos_example_spec1d_227132.fits', 'cosmos_example_spec1d_229356.fits', 'cosmos_example_spec1d_218066.fits', 'cosmos_example_spec1d_205346.fits', 'cosmos_example_spec1d_213771.fits', 'cosmos_example_spec1d_216137.fits']\n",
+    "C1 = Column(filenames, name = 'vUDS_spec_filename')\n",
+    "C2 = Column(filenames2, name = 'vUDS_spec_noise_filename')\n",
+    "C3 = Column(filenames3, name = 'DEIMOS_spec_filename')\n",
+    "T_short.add_column(C3)\n",
+    "T_short.add_column(C1)\n",
+    "T_short.add_column(C2)\n",
+    "T_short.add_column(T_final[\"id_candels\"])\n",
+    "\n",
+    "T_short.add_column(T_final[\"OBJECT_ID\"])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ascii.write(T_short, \"gal_lib_short1.dat\", overwrite = True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYwAAAEICAYAAABMGMOEAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3Xu8VXW97//XO1zIChUUsHSBgDtBIRQQNbKbGoruRDITtGO6a2/RMpM6lJ5dWrr3EaUd5U8r2B232y6KWbJRK0XZHrM05ZaKHhCRZEHFxUDNpVz8/P4YY+FkuS5jwhpr3t7Px2M+1prfcfuMscaanzm+3+/4DkUEZmZmHXlHqQMwM7PK4IRhZmaZOGGYmVkmThhmZpaJE4aZmWXihGFmZpk4YVhZkPSQpH/MMF9Iek8b0z4l6f6C98dLek7Sq5Imdma8WWTdJ9uVpAskPZJhvlsk/Us701+VdGj6e72kuyVtkfSzzoy3ljhhVBFJkyX9XtLfJK1Pf/+cJKXTT5D03+k/zepWlh+UTn9N0v+T9NF2tnWLpK3pP+VLkuZLOjzH3etQRPwkIk4uKLoauDEi9omIueX0AS7pG5K2SXolfa2QdKOkgwrm+YikN9NjXPgam07fuT/pvCHpFy22c1Ra/lBBmSRNS5Npk6QXJU2XtHfBPP0l/VzSxvR8eUrSBW3sS2Gcr0haLukfOveIFS/9u69K354FvAvoExGfzJqUbFdOGFVC0peB7wIzgHeT/HNcBBwPdE9n+xtwMzCtjdXcBiwB+gD/DNwpqV87m70+IvYBGoC1wP/Zw93obAOBZaUOoh1zImJf4ADg4yR/t0WFSQNYl37wFb4ebWN9G4D3S+pTUHY+sKLFfDcAFwKfBvYFTgVOBO4omOdHwBqSY9gnnfcv7ezLuvRc2A+YCvy7pKHtzN/VBgIrImJ7qQOpZE4YVUBSL5Jv05+LiDsj4pVILImIT0XEGwAR8XhE/AhY1co6hgCjgasioikifg48BXyio+1HRBPJh83IFuv8jKRnJf1V0n2SBhZMG5dexWyRdCOggmnvkfR/02kbJc1pscmPpt+O/yrppoIrqJ3fGiU9DxwK3J1+870W+CBwY/r+xjaO5c8k/Tnd9sOShhdMuyXd3r3pN+nfS/q7LPvUwfHbFhHLgEkkH/pfzrJcK7YCc4HJaTzdgLOBnxTEeBjwOeBTEfFoRGxPt/0JYLykE9NZjwFuiYi/pfMsiYhfZdiXiIhfAi8BRxZs9/D0KvSl9Ark7IJpfSTNk/SypMeBwmMqSTOVXDFvkfSkpPcWbHL/dv4ekZ5L3wSuBCalf/vPAz8AxqbvN2c7vOaEUR3GAnsD/7UH6xgOrIqIVwrK/pCWt0tST+AcYGVB2UTgfwFnAv2A35BcwSCpL/Bz4GtAX+B5kiuhZtcA9wP7A/2B/6/FJj9G8oF2FMkH4iktY4qIvwNeBE5Pv5VfkcZwSfr+kjZ251fAYcCBwGIKPmxT5wDfTGNbCfxrxn3qUETsIPkbfrCY5Vq4leRqAJLjsgxYVzD9JKAxIh5vse01wGPAuLToMeAmJdWch2TduKR3SJpAcgxWpmU9gfnAT0mO6znA9wqS8U3A68BBwGfSV7OTgQ8BQ4DeJEl1U8H0Vv8eLfbtKuB/k1zR7RMRN5FcfT+avu+ddf9qnRNGdegLbCy83Jb0O0mb0zrqD2VYxz7AlhZlW0iqLNryP9NvZ68AHwDOK5g2Bbg2Ip5N4/rfwMj0KuM04Jn0amgb8B3gzwXLbiOpQjg4Il6PiJZ1zdMjYnNEvAj8Ny2ubPZERNycXqG9AXwDOCq9gmv2i/RKbTtJMmnedkf7lNU6kiqqZgenf8fCV8924v8dcEBaHfRpkgRSqC/wpzYW/1M6HeCTJAn268ALkpZKOqaduA9Oz4Um4C7gSxGxJJ32MWB1RPxHerWymCS5npVeBX0CuDK9mnka+M+C9W4jOQcPB5SeT4Xxt/X3sBw4YVSHTUBfSXs1F0TE+9NvTpvI9nd+laT+udB+JMmgLd9KtzGI5IOisM56IPDd5g85kioKkbR3HExSP94caxS+B76Szvu4pGWSCr9xwq4fxK+RJLs9Jqmbksbf5yW9DKxOJ/UtmK2tbXe0T1k1kByrZusioneL1986WMePgEuAE0g+vAttJPkm35qD0ulExF8j4vKIGE7SHrYUmNtc/deKdem5sB9JG8mJBdMGAscVJj3gUyRtNv2Avdj1WP2x+ZeIWADcSHIV8hdJsyUVnqe5nAvWOieM6vAo8AZwxh6sYxlwqKTCK4qjyNBonH7T/yJJgqhPi9cAU1p80NWn34D/BAxoXj79EBpQsL4/R8Q/RcTBJFcq31MbXWmL1NHQzOeSHMOPAr1IEiFka4tod5+ykPQO4HSSb/Z74kck7RS/jIjXWkxbAAyQdGyLbQ8A3gc82HJlEbER+BZJUjyg5fQW874BfBUYobe6Mq8B/m+Lc2GfiLiYpM1mO7seq0NarPOGiDiapHp0CG132iiGh+neDU4YVSAiNpPU435P0lmS9knrkkcCO6sv0rIeQF3yVj0kdU/XsYLkW+RVafnHSRotf54xhvkk1SkXpkU/AK5orqeW1EvSJ9Np9wLDJZ2ZXhVdSvJtsznOT0rqn779K8k/945ij0sr/kLSEN6WfUkS7ybgnSTVaFm1u0/tkVQn6QiSNp53A98uYrtvExEvAB8m6enWctoKkr/NTyS9L72qGk7yd34gIh5IY7pO0nsl7ZV+ibgYWBkRm1qus5VtbAX+jaShGeAeYIik89J9rZN0jKQj0nabXwDfkPROScNIenaRxnGMpOMk1ZH08nudzjsX+jef/5aNE0aViIjrgS+RVOesJ/mHmEXybe936WwfIqk6+iXJt7gmksblZpOBMSQf0tOBsyJiQxFhzAC+ImnviLgLuA64Pa3eeZqk+2bzN9ZPptvYRNLI/NuC9RwD/F7Sq8A84Ivph+Ce+i5JvflfJd3QyvRbSapD1gLPkDT8ZpJhn1ozKd3HzST7uQk4OiIKG6kP1tvvw8jSc+2RFuspdAnwQ+DHJFWRvwYeYtcece8kqc7aTNKrbiAwoaPtFrgZOETS6WlHipNJzq91JNVI15F01GiOZ5+0/BbgPwrWsx/w7yTn5B9JjtG3ioijLQtIrp7/LGljJ6yvJij8ACUzM8vAVxhmZpaJE4aZmWXihGFmZpk4YZiZWSZ7dTxL5ejbt28MGjSo1GGYmVWMRYsWbYyI9gYZ3amqEsagQYNYuHBhqcMwM6sYkv7Y8VwJV0mZmVkmThhmZpaJE4aZmWVSVW0YZlZ7tm3bRmNjI6+//nqpQylrPXr0oH///tTV1e32OpwwzKyiNTY2su+++zJo0CDaHn29tkUEmzZtorGxkcGDB+/2elwlZWYV7fXXX6dPnz5OFu2QRJ8+ffb4KsxXGGZlYu6Stcy4bznrNjdxcO96pp0ylImjGkodVkVwsuhYZxwjJwyzMjB3yVqu+MVTNG1LHvWwdnMTV/ziKQAnjU4yc/4Kvvvgc21O/+JJhzF13JAujKjyuErKrMRmzl/BZXOW7kwWzZq27eCyOUuZOX9FiSKrLlPHDWH19L9n9fS/57jBB3Dc4AN2vl89/e/3KFl069aNkSNHMnz4cI466ii+/e1v8+abbwLw0EMP0atXL0aOHLnz9cADDwCwzz7JE2VXr16NJL7+9a/vXOfGjRupq6vjkksu2Vk2e/ZsDj/8cA4//HCOPfZYHnnkrcfd33PPPYwaNYqjjjqKYcOGMWvWrN3en7b4CsPMasrcJWtZ8uJmtu54k+OnL+iUqr/6+nqWLl0KwPr16zn33HPZsmUL3/zmNwH44Ac/yD333NPuOg499FDuuecerrnmGgB+9rOfMXz48J3T77nnHmbNmsUjjzxC3759Wbx4MRMnTuTxxx+nT58+XHjhhTz++OP079+fN954g9WrV+/RPrXGVxhmJTZ13BAaete3Oq2hd72rSTpRc9Xf1h3Jt//mqr+5S9Z22jYOPPBAZs+ezY033kgxD6irr6/niCOO2Dm80Zw5czj77LN3Tr/uuuuYMWMGffv2BWD06NGcf/753HTTTbzyyits376dPn36ALD33nszdOjQTtunZk4YZmVg2ilDqa/rtktZfV03pp3S+f/0tWzGfctbrfqbcd/yTt3OoYceyptvvsn69esB+M1vfrNLldTzzz/f6nKTJ0/m9ttvp7GxkW7dunHwwQfvnLZs2TKOPvroXeYfM2YMy5Yt44ADDmDChAkMHDiQc845h5/85Cc7q8Q6k6ukzMpAc5WIe0nla93mpqLK90Th1UWWKimA8ePH8/Wvf513vetdTJo0KdM2mns//fCHP+Spp57igQce4Fvf+hbz58/nlltu2e34W+OEYVYmJo5qcILI2cG961nbSnI4uI0qwd21atUqunXrxoEHHsizzz6bebnu3btz9NFH82//9m8sW7aMu+++e+e0YcOGsWjRIk488cSdZYsXL2bYsGE7348YMYIRI0Zw3nnnMXjw4E5PGK6SMrOa0RVVfxs2bOCiiy7ikksu2a17H7785S9z3XXX7WyPaPaVr3yFr371q2zatAmApUuXcsstt/C5z32OV199lYceemjnvEuXLmXgwIF7tB+t8RWGmdWM5iu4r9z5JFt3vElDJ1X9NTU1MXLkSLZt28Zee+3Feeedx5e+9KWd05vbMJp97Wtf46yzzmp1XcOHD9+ld1SzCRMmsHbtWt7//vcjiX333Zcf//jHHHTQQbzyyitcf/31TJkyhfr6enr27NnpVxcAKqYVv6gVSzcDHwPWR8R7W5k+DfhU+nYv4AigX0S8JGk18AqwA9geEWOybHPMmDHhByiZ1ZZnn32WI444oqhlJs16FIA5U8bmEVLZau1YSVqU9TM2zyuMW4AbgVtbmxgRM4AZAJJOB6ZGxEsFs5wQERtzjM/Makhrd3oPuvzenb/7Tu+O5ZYwIuJhSYMyzn4OcFtesZiZTR03xAlhD5W80VvSO4HxwM8LigO4X9IiSRd2sPyFkhZKWrhhw4Y8QzUzq2klTxjA6cBvW1RHHR8Ro4FTgc9L+lBbC0fE7IgYExFj+vXrl3esZmY1qxwSxmRaVEdFxLr053rgLuDYEsRlZmYFSpowJPUCPgz8V0FZT0n7Nv8OnAw8XZoIzcysWW4JQ9JtwKPAUEmNkj4r6SJJFxXM9nHg/oj4W0HZu4BHJP0BeBy4NyJ+nVecZmZ76i9/+Qvnnnsuhx56KEcffTRjx47lrrvuYtOmTZxwwgnss88+uwxTDrBo0SJGjBjBe97zHi699NKiBioslTx7SZ2TYZ5bSLrfFpatAo7KJyozq3lP3gEPXg1bGqFXfzjpSjjy7I6Xa0NEMHHiRM4//3x++tOfAvDHP/6RefPm0aNHD6655hqefvppnn5614qSiy++mNmzZ/O+972P0047jV//+teceuqpe7RreSuHNgwzs67x5B1w96WwZQ0Qyc+7L03Kd9OCBQvo3r07F130VuXJwIED+cIXvkDPnj35wAc+QI8ePXZZ5k9/+hMvv/wyY8eORRKf/vSnmTt37m7H0FWcMMysdjx4NWxrMfjgtqakfDctW7aM0aNHF7XM2rVr6d+//873/fv3Z+3aznsmR16cMMysdmxpLK58N3z+85/nqKOO4phjjmlzntbaK3ZnoMKu5oRhZrWjV//iyjMYPnw4ixcv3vn+pptu4sEHH6S9G4n79+9PY+NbSaqxsXGXhyWVKycMM6sdJ10JdS2efVFXn5TvphNPPJHXX3+d73//+zvLXnvttXaXOeigg9h333157LHHiAhuvfVWzjjjjN2Ooat4eHMzqx3NvaE6sZeUJObOncvUqVO5/vrr6devHz179uS6664DYNCgQbz88sts3bqVuXPncv/99zNs2DC+//3vc8EFF9DU1MSpp55a9j2kIMfhzUvBw5ub1Z7dGd68Vu3p8OaukjIzs0ycMMzMLBMnDDOreNVUtZ6XzjhGThhmVtF69OjBpk2bnDTaERFs2rTpbXecF8u9pMysojXf0+AHqLWvR48eu9xdvjucMMysotXV1TF48OBSh1ETXCVlZmaZOGGYmVkmrpLKydwla5lx33LWbW7i4N71TDtlKBNHNZQ6LDOz3eaEkYO5S9ZyxS+eomnbDgDWbm7iil88BeCkYWYVy1VSOZhx3/KdyaJZ07YdzLhveYkiMjPbc3k+0/tmSeslPd3G9I9I2iJpafq6smDaeEnLJa2UdHleMeZh5vwVrN3c1Oq0tZubmDl/RRdHZGbWOfK8wrgFGN/BPL+JiJHp62oASd2Am4BTgWHAOZKG5RinmZllkFvCiIiHgZd2Y9FjgZURsSoitgK3A+U/UHxq6rghfGfSSOrruu1SXl/Xje9MGsnUcUNKFJmZ2Z4pdRvGWEl/kPQrScPTsgZgTcE8jWlZqyRdKGmhpIXlcqfnxFENXHvmCBp61yOgoXc91545wg3eZlbRStlLajEwMCJelXQaMBc4DGjtwbZtDhITEbOB2ZA8DyOPQHfHxFENThBFcDdks/JXsiuMiHg5Il5Nf/8lUCepL8kVxYCCWfsD60oQonWR5m7Iazc3EbzVDXnukrWlDs3MCpQsYUh6tySlvx+bxrIJeAI4TNJgSd2BycC8UsVp+XM3ZLPKkGe32tuAR4GhkholfVbSRZIuSmc5C3ha0h+AG4DJkdgOXALcBzwL3BERy/KK00pr0qxH2+2GPGnWo10ckZm1xc/0tpI7fvqCVpNGQ+96fnv5iSWIyKx2+JneVWrukrUcP30Bgy+/l+OnL6iaOv5ppwxttRvytFOGligiM2uNx5KqENU8PlVz/O4lZVbenDAqRHsNw9XwwepuyGblz1VSFcDjU5lZOXDCMDOzTJwwKoDHpzKzcuA2jArhhmEzKzUnjArihmEzKyUnDKtaHtDQ8lZr55gThlWlar5vxcpDLZ5jbvS2quQBDS1vtXiOOWFY1fGAhpa3Wj3HnDCs6syZMpaG3vWtTmvoXc+cKWO7OCKrNrV6jjlhWFXygIaWt1o8x9zobVXJ961Y3mrxHPPzMMzMapifh2FmZp3OVVKWm2q9qala96sc+NiWt9wShqSbgY8B6yPiva1M/xTw1fTtq8DFEfGHdNpq4BVgB7A96+WSlY9qvampWvcLSv9hXc3HtlrkWSV1CzC+nekvAB+OiCOBa4DZLaafEBEjnSwqz8z5K7hsztJWb2q6bM7Sin1+R7XuF7z1Yb12cxPBWx/WXfkY4Gq+Ea5aHq+cW8KIiIeBl9qZ/ruI+Gv69jGgf16xmFn7Sv1hXc0PCSuHZNxZyqXR+7PArwreB3C/pEWSLmxvQUkXSlooaeGGDRtyDbKSlPIbzdRxQ9q9qalSn99RrftVq3ctd5VSJ+POVPKEIekEkoTx1YLi4yNiNHAq8HlJH2pr+YiYHRFjImJMv379co62MpTDN5pqvampGverHO5artaHhFXblVNJE4akI4EfAmdExKbm8ohYl/5cD9wFHFuaCCtTOXyjmTiqgWvPHEFD73pE8sFz7ZkjKr7xslr3qxwSYbUe22qS6417kgYB97TRS+oQYAHw6Yj4XUF5T+AdEfFK+vt84OqI+HVH2/ONe8k3mu8++Fyb07940mEV+23N8lXqXlLVqmXvL0iScbkkw2Ju3MuzW+1twEeAvpIagauAOoCI+AFwJdAH+J4keKv77LuAu9KyvYCfZkkWZnvCH5Z+omNeqmkIEQ8NUoXK/RtNufHxqn7+QtA2Dw1S41wXXJxyaPOx/JRDJ5Bq4SsMq2mTZj3K719o83Yhjht8QNU+26BWHD99Qas9lRp61/Pby08sQUTlxVcYZhmVQ5dSy0+1dWstNScMq3nl0KXUrBJ4tFqredXUi8V2NXXcEAb37elODZ3ECcMMdymtZv5C0HmcMMys6vkLQecoOmFIegewT0S8nEM8Ncf9w82sUmRq9Jb0U0n7pUN1PAMslzQt39Cqn/uHm1klydpLalh6RTER+CVwCHBeblHVCN8wZmaVJGvCqJNUR5Iw/isituUYU03wMwjMrNJkTRizgNVAT+BhSQOBLXkFVQt8w5iZVZqsCePuiGiIiNMiGUvkReAzOcZVE3zDmJlVkqwJ4+eFb9KkcXvnh1NbPEigmVWSdrvVSjocGA70knRmwaT9gB55BlYr3D/czCpFR/dhDAU+BvQGTi8ofwX4p7yCMjOz8tNRwnh/RPyDpCsj4uouicjMzMpSR20YpxV0py2apJslrZf0dBvTJekGSSslPSlpdMG08yU9l77O353tW4178g6Y+V74Ru/k55N3lPd6S62Y/aq0Y1BB58IT82bx52+8hzev6sWfv/Eenpg3qxMC7RwdXWH8GtgI9JRUOBSISNq+9+tg+VuAG4Fb25h+KnBY+joO+D5wnKQDSJ4BPgYIYJGkeRHx1w62Z5Z48g64+1LYlt7rsmVN8h7gyLPLb72lVsx+VdoxqKBz4Yl5s3jvoq9Rr60geDcb6LXoazwBHDNhyu7H2knavcKIiGkR0Qu4NyL2K3jtmyFZEBEPA20/zgzOAG6NxGNAb0kHAacA8yPipTRJzAfGZ94rswevfusfudm2pqS8HNebo7lL1nL89AUMvvxejp++oPWhZ4rZr0o7BhV0LgxYPCNJFgXqtZUBi2fs9jo7U6ZutRFxRk7bbwDWFLxvTMvaKn8bSRdKWihp4YYNG3IK0yrOlsbiyku93pxkHq+smP2qsGNQKefCpFmPcmC0/hl2YGwsi9Ef2k0Ykh5Jf74i6eWWPzth+2qlLNopf3thxOyIGBMRY/r169cJIVlV6NW/uPJSrzcnmccrK2a/KuwYVMq5MGfKWNar9c+w9epbFqM/dFQl9YH0576FVVFZq6QyaAQGFLzvD6xrp9wsm5OuhLoWQ6/U1Sfl5bjeHBT1POti9quCjgFQUefCmtHTaIruu5Q1RXfWjC6PwcEzP9NbUjdJB0s6pPnVCdufB3w67S31PmBLRPwJuA84WdL+kvYHTk7LzLI58mw4/QboNQBQ8vP0G/a8UTav9ZZaMftVaceggs6FYyZM4emj/4U/0483Q/yZfjx99L+URYM3gJJRPjqYSfoCSa+lvwBvpsUREUd2sNxtwEeAvumyVwF16cI/kCSSXlTjgdeAf4iIhemynwH+V7qqf42I/+gozjFjxsTChQs73B+zWtHchuHnWVtbJC2KiDGZ5s2YMFYCx0XEpj0NLk9OGGZv56c6WnuKSRhZH9G6Bg9nblaRPF6ZdZaOBh/8UvrrKuAhSfcCbzRPj4hv5xibmZmVkY6uMPZNf76YvrqnLzMzqzHtJoyI+GbLMknvAPZJn/FtZmY1IlO3Wkk/lbSfpJ7AM8BySeXRMdjMzLpE1vswhqVXFBOBXwKHAOflFpWZmZWdrAmjrmCY8/+KiG20MVSHmZlVp6zdamcBq4E/AA9LGgi4DcPMOuT7QKpHphv3Wl1Q2isitndyPHvEN+6ZdY0sSWDm/BV898Hn2lzHF086jKnjhuQdqnWg027cK7gPoy2+D8OsxrQcbqR5yHRgl6QxddwQ7lzU2OoAiA29650sKlBHbRj7pq8xwMW89ayKi4Bh+YZmZuUo85DpwLo2Rsttq9zKW0fDm38zvRejLzA6Ir4cEV8GjiYZctzMasikWY+2O2R6y4f8HNy7vtV52yq38pa1l9QhQOFzA7cCgzo9GjMra3OmjKWhjQ/7ht71uzzkp6jncVhFyNpL6kfA45LuIulO+3Hg1tyisrLlHi827ZShrQ6ZPu2UobvMN3XcEKaOG+Jzpopk7iUlaTTwwfTtwxGxJLeodpN7SeXLz1awZk4C1SOP4c0B3gm8HBH/IamfpMER8cLuhWiVpq0ukk3bdnDZnKW8sPFv7vVSQzxkem3KOpbUVcBXgSvSojrgx3kFZWZm5Sdro/fHgQnA3wAiYh1vDX1uNWDquCHtNnb66sKs+mVNGFsjaewIgHTU2g5JGi9puaSVki5vZfpMSUvT1wpJmwum7SiYNi9jnJajaacMpb6u2y5lrTV2mll1ytqGcYekWUBvSf8EfAb4YXsLSOoG3ASMAxqBJyTNi4hnmueJiKkF838BGFWwiqaIGJkxPusCzXXWbuw0q02ZEkZEfEvSOJIBB4cCV0bE/A4WOxZYGRGrACTdDpxB8jyN1pwDXJUp6hJxzxA3dprVssy9pNIEMR+SqwdJn4qIn7SzSAOwpuB9I3BcazOmo98OBhYUFPeQtBDYDkyPiLltLHshcCHAIYccknFvipd1/Bwzs2rVbhtG+pS9KyTdKOlkJS4BVgFnd7ButVLW1k0fk4E7I6JwgJpD0r7B5wLfkfR3rS0YEbMjYkxEjOnXr18HIe2+YsbPMTOrRh01ev+IpArqKeAfgfuBTwJnRMQZHSzbCAwoeN8fWNfGvJOB2woL0p5YpFVaD7Fr+0aX8hAHZmYdV0kdGhEjACT9ENhI8s3/lQzrfgI4TNJgYC1JUji35UyShgL7A48WlO0PvBYRb0jqCxwPXJ9hm2ZmlpOOEsa25l8iYoekFzImCyJie1p9dR/QDbg5IpZJuhpYGBHNXWXPAW6PXccoOQKYJelNkqug6YW9q7ra1HFDGNy3p4fFMLOa1u5YUpJ2kN6sR9ImUQ+8lv4eEbFf7hEWIe+xpKq1l1Ql7Jef3mZdpRL+HzpTMWNJ7fYjWsuRBx8sXqUNKDh3yVq+cueTbN3xJg018M9sXadWv5QUkzCy3ultVaqSen81J7etO94E3uraPHfJ2hJHZtXAw990zAmjhhX79LRSq6TkZpXJj5RtnxNGDSvm6WnlwP/Mljc/UrZ9Thg1rpIGFPQ/s+Wtkv4fSsEJo8ZNHNXAtWeOoKF3PSK5sijXBm//M1ueZs5fwWVzlrZa7XnZnKW+QRf3krIKUas9WMzy5m61ZmY1oDPuGcnrmd5mZlYmSjGCttswzMwqUCm6mTthmJlVmFLdQ+WEYWZWYUp1D5UThplZBSpFN3M3epuZVaDmhu2uHFnXCcPMrEJNHNXQpTfZukrKzMwyccIwM7NMck0YksZLWi5ppaTLW5l+gaT24r+nAAAMgElEQVQNkpamr38smHa+pOfS1/l5xmlmZh3LrQ1DUjfgJmAc0Ag8IWleK8/mnhMRl7RY9gDgKmAMEMCidNm/5hWvmZm1L88rjGOBlRGxKiK2ArcDZ2Rc9hRgfkS8lCaJ+cD4nOI0M7MM8kwYDcCagveNaVlLn5D0pKQ7JQ0oclkzM+sieSYMtVLWcmjcu4FBEXEk8ADwn0Usm8woXShpoaSFGzZs2O1gzcysfXkmjEZgQMH7/sC6whkiYlNEvJG+/Xfg6KzLFqxjdkSMiYgx/fr165TAzczs7fJMGE8Ah0kaLKk7MBmYVziDpIMK3k4Ank1/vw84WdL+kvYHTk7LzMysRHLrJRUR2yVdQvJB3w24OSKWSboaWBgR84BLJU0AtgMvAReky74k6RqSpANwdUS8lFesZmbWMT9xz8wqUmc8bc78xD0zq3KleNqceWgQM6swM+ev4LI5S1t92txlc5Yyc/6KEkVW/ZwwzKyiTB03pNV+95D0x586bkhXhlNTaj5hzF2yluOnL2Dw5fdy/PQFzF2yttQhmVk7Zs5f0fpNWSQ3a/kKIz812+g9c/4Kvvvgc21O/+JJh/mbilmZatmGAcnT5q49c4TbMIpUTKN3zV5hTB03pN1n4jpZmJWviaMauPbMETT0rkck/7NOFvmr6V5S6zY3FVVuZuWjq582ZzV8hQFwcBtXGG2Vm5nVsppNGDPnr2BtG1cSazc3ueHMzKyFmm30bua7Rc2slvlO7yK4HtTMLJuarZIyM7PiOGGYmVkmThhmZpaJE4aZmWXihGFmZpnUfC8pszw9MW8WAxbP4MDYwHr1Y83oaRwzYUqpwzLbLU4YZjl5Yt4s3rvoa9RrKwjezQZ6LfoaT4CThlWkXKukJI2XtFzSSkmXtzL9S5KekfSkpAclDSyYtkPS0vQ1L884zfIwYPGMJFkUqNdWBiyeUaKIzPZMbglDUjfgJuBUYBhwjqRhLWZbAoyJiCOBO4HrC6Y1RcTI9DUhrzjN8jBp1qMcGBtanXZgbGTSrEe7OCKzPZfnFcaxwMqIWBURW4HbgTMKZ4iI/46I19K3jwH9c4zHrMvMmTKW9erX6rT16sucKWO7OCKzPZdnwmgA1hS8b0zL2vJZ4FcF73tIWijpMUkT21pI0oXpfAs3bGj9G51ZKawZPY2m6L5LWVN0Z83oaSWKyGzP5Nno3dpjd1sd6VDS/wDGAB8uKD4kItZJOhRYIOmpiHj+bSuMmA3MhmTwwT0P26xzHDNhCk9A2ktqI+vVlzVHu5eUVa48E0YjMKDgfX9gXcuZJH0U+GfgwxHxRnN5RKxLf66S9BAwCnhbwjArZ8dMmAJpgnh3+jKrVHlWST0BHCZpsKTuwGRgl95OkkYBs4AJEbG+oHx/SXunv/cFjgeeyTFWMzPrQG5XGBGxXdIlwH1AN+DmiFgm6WpgYUTMA2YA+wA/kwTwYtoj6ghglqQ3SZLa9IhwwjBL+TkuVgo1/wAls0ozd8larvjFUzRt27GzrL6uG9eeOcJJw4pWzAOUPJaUWYWZcd/yXZIFQNO2Hcy4b3mJIrJa4YRhVkEmzXq03WfR+4ZAy5MThlkFmTNlLA2961ud1tC73jcEWq6cMMwqzLRThlJf122Xsvq6bkw7ZWiJIrJa4dFqzSpMc8O2e0lZV3PCMKtAE0c1OEFYl3OVlJmZZeKEYWZmmThhmJlZJk4YZmaWiROGmZll4oRhZmaZOGGYmVkmThhmZpaJE4aZmWXihGFmZpk4YZiZWSZOGGZmlkmuCUPSeEnLJa2UdHkr0/eWNCed/ntJgwqmXZGWL5d0Sm5BPnkHzHwvfKN38vPJO7p23lJvv9LmLWadxchrvXnFkNe8eai0/cpjvZUUaztye6a3pG7ACmAc0Ag8AZwTEc8UzPM54MiIuEjSZODjETFJ0jDgNuBY4GDgAWBIROxouZ1CRT/T+8k74O5LYVvBE8zq6uH0G+DIs/Oft9Tbr7R5i1lnMfJab14x5DVvHiptv/JYb5nHWi7P9D4WWBkRqyJiK3A7cEaLec4A/jP9/U7gJElKy2+PiDci4gVgZbq+zvXg1bsebEjeP3h118xb6u1X2rzFrLMYea03rxjymjcPlbZfeay3kmLtQJ4JowFYU/C+MS1rdZ6I2A5sAfpkXBYASRdKWihp4YYNG4qLcEtj9vI85i319itt3mLWWYy81ptXDHnNm4dK26881ltJsXYgz4ShVspa1n+1NU+WZZPCiNkRMSYixvTr16+4CHv1z16ex7yl3n6lzVvMOouR13rziiGvefNQafuVx3orKdYO5JkwGoEBBe/7A+vamkfSXkAv4KWMy+65k65M6vwK1dUn5V0xb6m3X2nzFrPOYuS13rxiyGvePFTafuWx3kqKtQN5JowngMMkDZbUHZgMzGsxzzzg/PT3s4AFkbTCzwMmp72oBgOHAY93eoRHnp00EPUaACj52VaDUR7zlnr7lTZvMessRl7rzSuGvObNQ6XtVx7rraRYO5BbLykASacB3wG6ATdHxL9KuhpYGBHzJPUAfgSMIrmymBwRq9Jl/xn4DLAduCwiftXR9oruJWVmVuOK6SWVa8Loak4YZmbFKZdutWZmVkWcMMzMLBMnDDMzy8QJw8zMMqmqRm9JG4A/dsGm+gIbu2A7nc1xd51KjBkcd1crh7gHRkSmu56rKmF0FUkLs/YqKCeOu+tUYszguLtapcXtKikzM8vECcPMzDJxwtg9s0sdwG5y3F2nEmMGx93VKiput2GYmVkmvsIwM7NMnDDMzCwTJ4wWJI2XtFzSSkmXtzL9S5KekfSkpAclDSyYtkPS0vTVcij3Usd9gaQNBfH9Y8G08yU9l77Ob7lsCWOeWRDvCkmbC6aV5FhLulnSeklPtzFdkm5I9+lJSaMLppXkOKfb7ijuT6XxPinpd5KOKpi2WtJT6bHu0tE9M8T9EUlbCs6FKwumtXt+lTDmaQXxPp2eywek00p2rDOJCL/SF8kw7M8DhwLdgT8Aw1rMcwLwzvT3i4E5BdNeLeO4LwBubGXZA4BV6c/909/3L4eYW8z/BZIh8kt9rD8EjAaebmP6acCvSJ4a+T7g96U8zkXE/f7meIBTm+NO368G+pbp8f4IcM+enl9dGXOLeU8neQ5QyY91lpevMHZ1LLAyIlZFxFbgduCMwhki4r8j4rX07WMkTwMstQ7jbscpwPyIeCki/grMB8bnFGehYmM+B7itC+JqV0Q8TPLslracAdwaiceA3pIOonTHGeg47oj4XRoXlM95neV4t2VP/if2SJExl8V5nZUTxq4agDUF7xvTsrZ8luTbZLMekhZKekzSxDwCbEPWuD+RVjncKan5EbjF7nNnybzdtNpvMLCgoLhUx7ojbe1XqY7z7mh5Xgdwv6RFki4sUUztGSvpD5J+JWl4Wlb2x1vSO0m+NPy8oLisj/VepQ6gzKiVslb7HUv6H8AY4MMFxYdExDpJhwILJD0VEc/nEOfbwmmlrGXcdwO3RcQbki4C/hM4MeOyeShmu5OBOyNiR0FZqY51R9rar1Id56JIOoEkYXygoPj49FgfCMyX9P/Sb9HlYDHJWEivKnnC51ySRzpXwvE+HfhtRBRejZTzsfYVRguNwICC9/2BdS1nkvRR4J+BCRHxRnN5RKxLf64CHiJ59GxX6DDuiNhUEOu/A0dnXTYnxWx3Mi0u20t4rDvS1n6V6jhnJulI4IfAGRGxqbm84FivB+4iqe4pCxHxckS8mv7+S6BOUl8q4HjT/nlddscacKN34YvkimsVSfVHc0PZ8BbzjCJpTDusRfn+wN7p732B5+i6RrYscR9U8PvHgcfS3w8AXkjj3z/9/YByiDmdbyhJQ6DK4Vin2xxE242wf8+ujd6Pl/I4FxH3IcBK4P0tynsC+xb8/jtgfBnF/e7mc4Pkw/XF9NhnOr9KEXM6vRdJO0fPcjrWHb1cJVUgIrZLugS4j6SXxc0RsUzS1cDCiJgHzAD2AX4mCeDFiJgAHAHMkvQmyZXb9Ih4pozivlTSBGA7yYl6QbrsS5KuAZ5IV3d17HqJXMqYIWkUvD3S/6JUyY61pNtIeub0ldQIXAXUpfv0A+CXJD2lVgKvAf+QTivJcS4i7iuBPsD30vN6eySjqL4LuCst2wv4aUT8uoziPgu4WNJ2oAmYnJ4rrZ5fZRIzJF/a7o+IvxUsWtJjnYWHBjEzs0zchmFmZpk4YZiZWSZOGGZmlokThpmZZeKEYWZmmThhmJlZJk4YZmaWyf8Prth3JeMGQ+gAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#Plotting redshifts to determine whether the different catalogues match up properly\n",
+    "x = np.linspace(min(T[\"ZTRUE\"]), max(T[\"ZTRUE\"]), len(T[\"ZTRUE\"]))\n",
+    "plt.errorbar(x = x, y = T[\"ZTRUE\"], yerr = T[\"ZERR\"], fmt = 'o', capsize = 4, label = 'DEIMOS')\n",
+    "plt.errorbar(x = x, y = T_final[\"Z_06\"], fmt = 'o', capsize = 4, label = 'G10')\n",
+    "plt.title(\"G10 Redshift and DEIMOS Redshift\")\n",
+    "plt.ylabel(\"Redshifts\")\n",
+    "plt.legend(loc='upper right')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0, 0.5, 'vUDS Redshift')"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEWCAYAAACJ0YulAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3XuYHGWZ9/HvzxBhRCRAgsKEkLjGuCKH6IiywRUFNsByiBEILK6gaHAvUQQ2StZ9PeC6RKMivKDCKi+iEgIxxqi4gSWiKASZEEw4GIgcM9ElCQQ5jBDC/f5RT7eVTndP98z09PTM73NdfU3X89ThruqevqueqnpKEYGZmRnAy5odgJmZDR5OCmZmVuSkYGZmRU4KZmZW5KRgZmZFTgpmZlbkpGCDhqQrJf1HDeM9LOmwCnXvkLQ6NzxJ0gpJT0v6eH/Ga/1D0s2SPlTDeCHpdRXqTpF0Q254iqQHJD0jaVp/xjvUOSkMEeV+KCWdJunX6f349E/1THr9r6SfSjq8ZJqDJd0q6SlJT0j6jaS3Vljm5yRtTvPblKY7qHFr2bOIuCUiJuWKPgncHBE7RcTFtSae/pY+n+6UnArb6iOSXpYb50pJL+Q+o2ck/S7VFT6/7XLjhqRjS5bz9VR+Wq5srKQfSNoo6VlJv5V0dMl0x0m6S9KfJW2QdJOk8RXWJR/nE5JulPSGfttYvRARP4iIf8gVnQ9cEhGvjIhFtSYec1IYjkZFxCuB/YEbgR8VfkAkvQr4KfB/gV2BduDzwPNV5jc/zW808AvgusaF3it7A/c0O4jkmIjYiSymOcCngO+UjPPl9ENWeO1fZX73A6cWBlLCOAH4Q65sV+DXwAvAPmSf04XA1ZKOT+O8DrgKOBfYGZgAfAN4qcqyv5w+93agq8x6NNtg+txbipNCi5B0nqQFJWUXSbq4N/OLiD9FxEXA54AvpT3W16e6eRGxJSK6I+KGiFhZw/xeBH4AtEsak4vx6LQHWtg73i9XN1nSnWnveT6wQ65udDqS2ZT2Rm/J71UDB0hamY5o5kvaIU13iKS16f1S4F3AJWmvdiZwCvDJNPyT0vWQ9C1JXykp+7Gkc9L7T0nqSjGvlnRoT9umzLZ6KiIWAzOAUyW9qd55JD8BpkjaJQ0fAawE/pQb52zgGeD09Jl3R8Q84IvAVyUJOAB4KCJuiszTEfHDiHi0hnXpBq5N8yiS9EFJ90l6UtISSXvn6g6X9Pv02V0CKFf3Okm/THUb0vci7zBlzUJPSro0xV96VPwH4LXAT9LnfAHwDv76Pbikp/UazpwUWsc84Ki0N4+kEcCJwNV9nO9CYHdgEtme5xZJ35V0ZO7HpkeSXg68H9gIPJnK3gxcAZwB7AZcBiyWtH0afxHwPbKjkuuA9+ZmeS6wFhgDvBr4NyDfJ8uJZD+CE4D9gNNKY4qIdwO3AGemve7LyRJXYW/8mDKrcjUwI/djswvwD8A1kiYBZwJvTXv8U4GHa91GZeL7bVrHd/RyFn8BFgMnpeH3k+3x5x0O/DAiSvf6rwXGke0I3Am8QdKFkt4l6ZW1BiBpR+BkYE2ubBrZ5zWd7PO7hez7i6TRwA+Bfyc7avkDMCU3yy8ANwC7AGPJjlrzjgbeSnakeyLZZ7CViPgb4FGyI7NXRsRstv4enFnr+g1HTgotIiIeIfvnLZw0ezfwXEQs6+Os16W/u0bEn4GDyX58/wtYL2mxpFdXmf5ESZuAbuDDwPHpqIE0fFlE3J6OPL5L1hT19vQaCXw9IjZHxALgjtx8NwN7AHun+lti6466Lo6IdRHxBNke81Z7qn1wC9n6F36ojwdui4h1wBZge+CNkkZGxMMR8YcK86nVOrKkWPCv6eio8PpuD9NfBbxf0s7AO8kSbd5o4I9lpiuUjY6IB4FDyJqCrgU2pPMG1ZLDv6bP/Wmy78w/5+rOAC6IiPvSd+E/yY7s9gaOAu6NiAURsRn4Olsf2Wwma/rZMyL+EhG/LlnunIjYlI5ifkH/fe6WOCm0lqvJ9soA/omtjxJeJPuRzRtJ9k9WTXv6+wRA+kc+LSLGAm8C9iT7x63k2ogYRbY3fzfwllzd3sC5+R85YK80zz2BrpIf+kdy7+eS7X3eIOlBSeeVLDf/Q/IcUPPebTUpnmvYejv/INWtAT5B1uT2uKRrJO3Zx0W2k7Z98pWIGJV7nVppwhTTr8n2xv8d+GlqzsnbQJZcS+2RqycilkXEiRExhiwh/j3w6SqL/kr63MeT7RDkT+7vDVyU+8yfIGsiaif73B/LxR/5YbILAwT8VtI9kj5YstyGfO72V04KreU64BBJY4H3sHVSeJTsHzRvAlv/0JbzHuBxYHVpRUT8HriSLDlUFREbyPYQPyep8IPzGPDFkh+5V6Q27T+SnX9QbjbjcvN7OiLOjYjXAscA5/Sm/b5cqDWMMw84Pu3Zvo2suaMQ19URcTDZD18AX+ptIMqu6monOxHcF98na24rbToC+B/gvSXnYyBrenmMrMlwKxFxB1mzYi2f+6PAWWRJoC0VPwacUfK5t0XErWSf+16F6dPnv1dufn+KiA9HxJ5k36dvqMJlqHVyd9A1clJoIRGxHrgZ+H9kJwbvy1XPBz4h6Q3KdAAfJNvr3YakV0s6E/gsMDsiXkrTnpuSDpL2IttjrqmJKiWRJWR7e5A1QX1E0ttSTDtK+kdJOwG3kR3dfFzSdpKmAwfm4js6nXQU8GeyppsttcTRg/8lOwlZbT1WAOuBbwNLImJTimmSpHdL2p6sPb+7NzFJepWyS0KvAb4fEavqnUeJi8nOHfyqTN2FwKuA70h6jaQdJJ1MdhQwKyJC2WXIH5a0e4rvDcCx1P6530jWDDYzFX0LmC1pnzS/nSWdkOp+Buwjabqyq6U+DrymMC9JJxS+f2TnpoIB+twt46TQeq4GDmPbE8z/RZYsfgI8RbbX+OmI+O+S8TZJehZYRda+e0JEXJHqnibbM749jbOMrEno3DrimwvMlLR7RHSSnVe4hOwffA3phHBEvEB2IvK0VDeDbO+0YCLZXu4zZAnkGxFxcx1xVPIdsnMCmySVtr/nzWPb7bw92aWkG8iaMXYnO6FauHmqp0sgfyLpabI96U8DXwM+UDJO4cqowmtDTysUEU8UrhwqU7eRrM1/B+BesgsBzgH+OSIKV/ZsIksCqyQ9A/w38CPgyz0tO2duin37iPgR2RHUNZL+TPYdOjLFs4Hsstk5KZaJwG9y83kr2ffvGbKT6GdFxEN1xFHJRWRHf0+ql1fsDRcq8z0yM7NhykcKZmZW5KRgZmZFTgpmZlbkpGBmZkXbNTuAeo0ePTrGjx/f7DDMzFrK8uXLN6SbE6tquaQwfvx4Ojs7mx2GmVlLkdTTjayAm4/MzCzHScHMzIqcFMzMrMhJwczMipwUzKwuF954PxfeuE3nqjZEtNzVR2bWPItWdHHRTQ8AsGD5WmZNncS0ye09TGWtxEcKZlaTRSu6mL3wr718d23qZvbCVSxa0dXEqKy/OSmYWU3mLllN9+atH23QvXkLc5ds83wma2FOCmZWk3WbSp/0Wb3cWpOTgpnVZM9RbXWVW2tyUjCzmsyaOom2kSO2KmsbOYJZUyc1KSJrBF99ZGY1KVxl9In5dwHQPqrNVx8NQU4KZlazaZPbeWjDswCcffjrmxyNNYKTgpnVxclgaPM5BbNhyncmWzk+UjAbZhat6GLuktV0pUtJJ4ze0ecFrMhJwWwYKBwRTBi9I7MXrtrqJrTCXcpODAZOCmZDWulRwai2kRXvSnZSMHBSMBuyCn0V5ZPApu7NZcf1XclW4BPNZkNUub6KKvFdyVbgpGA2RNW69++7ki3PScFsiKq097/LK0bSnqu7YPq+Pp9gRT6nYDZEzZo6aZtzCm0jR/DZY/Zh2uT24hVJTgiW56RgNkQVfuzzVx/ljwp8Z7KV07DmI0lXSHpc0t0V6k+RtDK9bpW0f6NiMRtuCkcBD214lt+c927OOnQiZx060UcF1qNGHilcCVwCXFWh/iHgnRHxpKQjgcuBtzUwHrNhofAc5YtveoAgu2HNRwVWq4YlhYj4laTxVepvzQ0uA8Y2KhazoapwRFD40c8/RznSOL5j2eoxWM4pnA78vFKlpJnATIBx48YNVExmg1rhiABgwfK1zJo6qepzlJ0UrBZNTwqS3kWWFA6uNE5EXE7WvERHR0dUGs9suMgfEQB0bere5kqjPN+xbLVqalKQtB/wbeDIiNjYzFjMWkmlI4IRElti2/0m37FstWrazWuSxgELgX+OCHfqblaHSnv+WyL8HGXrk0ZekjoPuA2YJGmtpNMlfUTSR9IonwF2A74h6S5JnY2KxWyoqbTn3z6qjQum7wuAUpnvWLZ6NPLqo5N7qP8Q8KFGLd9sKKt0t/KsqZOKz1E++/DXc+GN9zshWF0UZdofB7OOjo7o7PRBhdmiFV18Yv5dQHaEUEgIZuVIWh4RHT2N1/Srj8ysdwpHBOAuK6z/OCmYtTAnA+tv7jrbzMyKnBTMzKzIScFsEJhx2W3NDsEMcFIwa6pFK7qYMmcptz/0BFPmLGXRiq5mh2TDnE80mzVJof+iwr0Ghf6LwD2aWvP4SMGsSar1aGrWLE4KZk1Sqf8i92hqzeSkYNYklfovco+m1kxOCmZNMmvqJPdoaoOOTzSbNUnhZPLcJavp2tTt/otsUHBSMGuiaZPbmTa5nRmX3cb8Mw5qdjhmbj4yGwycEGywcFIwM7MiJwUzMytyUjAzsyInBTMzK3JSMDOzooYlBUlXSHpc0t0V6iXpYklrJK2U9OZGxWJmZrVp5JHClcARVeqPBCam10zgmw2MxczMatCwpBARvwKeqDLKccBVkVkGjJK0R6PiMTOznjXznEI78FhueG0qMzOzJmlmUlCZsig7ojRTUqekzvXr1zc4LDOz4auZSWEtsFdueCywrtyIEXF5RHRERMeYMWMGJDgzs+GomUlhMfD+dBXS24GnIuKPTYzHzGzYa1gvqZLmAYcAoyWtBT4LjASIiG8B1wNHAWuA54APNCoWMzOrTcOSQkSc3EN9AB9t1PLNzKx+vqPZzMyKnBTMzKzIScHMzIqcFMzMrMhJwczMipwUzMysyEnBzMyKnBTMzKzIScHMzIqcFMzMrMhJwczMinpMCpLOqqXMzMxaXy1HCqeWKTutn+MwM7NBoGIvqZJOBv4JmCBpca5qJ2BjowMzM7OBV63r7DuBPwKjga/myp8GVjYyKDMza45qSWFeRLxZ0h8i4pcDFpGZmTVNtaTwckmnAgdJml5aGRELGxeWmZk1Q7Wk8BHgFGAUcExJXQBOCmZmQ0zFpBARvwZ+LakzIr4zgDGZmVmTVLv66N0RsRR40s1HZmbDQ7Xmo3cCS9m26QjcfGRmNiRVaz76bPr7gd7OXNIRwEXACODbETGnpH4c8F2y8xYjgPMi4vreLs/MzPqm2pECAJK2B94LjM+PHxHn9zDdCOBS4HBgLXCHpMURcW9utH8Hro2Ib0p6I3B9Wo6ZmTVBj0kB+DHwFLAceL6OeR8IrImIBwEkXQMcB+STQgCvSu93BtbVMX8zM+tntSSFsRFxRC/m3Q48lhteC7ytZJzPATdI+hiwI3BYuRlJmgnMBBg3blwvQjEzs1rU0iHerZL27cW8VaYsSoZPBq6MiLHAUcD3JG0TU0RcHhEdEdExZsyYXoRiZma1qHZJ6iqyH/HtgA9IepCs+UhARMR+Pcx7LbBXbngs2zYPnQ4cQTbD2yTtQNbX0uP1rISZmfWPas1HR/dx3ncAEyVNALqAk8h6Xc17FDgUuFLS3wI7AOv7uFwzM+ulis1HEfFIRDxCljj+lN5PIDtZ/FRPM46IF4EzgSXAfWRXGd0j6XxJx6bRzgU+LOl3wDzgtIgobWIyM7MBop5+gyXdBXSQXSq6BFgMTIqIoxoeXRkdHR3R2dnZjEWbmbUsScsjoqOn8Wo50fxS2uufDnw9Is4G9uhrgGZmNvjUkhQ2p6ewvR/4aSob2biQbDiYcdltzQ7BzMqoJSl8ADgI+GJEPJROHH+/sWHZULVoRRdT5izl9oeeYMqcpSxa0dXskMwsp8eb11K3FB/PDT8EzKk8hVl5i1Z0MXvhKro3bwGga1M3sxeuAmDa5PZmhmZmSS33KZRVw30KZluZu2R1MSEUdG/ewtwlq50UzAaJWu5T+Gj6+7309xTguYZFZEPWuk3ddZWb2cCr1nX2IwCSpkTElFzVeZJ+A1TtJdWs1J6j2ugqkwD2HNXWhGjMrJxaTjTvKOngwoCkvyPrvM6sLrOmTqJt5IitytpGjmDW1ElNisjMStWSFE4HLpX0sKSHgG8AH2xsWNbKKl1uOm1yOxdM35f2dGTQPqqNC6bv6/MJZoNIj3c0F0eUXpXG77GLi0byHc2D16IVXcxdspquTd20j2pj1tRJFX/wZ1x2G/PPOGiAIzQbvvrtjmZJr5b0HWB+RDwl6Y2STu+XKG3IKFxuWjhnULjctNJ9CE4IZoNTLc1HV5L1ebRnGr4f+ESjArLWVO1yUzNrHbUkhdERcS3wEhR7P91SfRIbbny5qdnQUEtSeFbSbqQb2SS9nRq6zrbhpdJlpb7c1Ky11JIUziHrLvtv0v0JV5Hr9sIMfLmp2VBRS99Hd0p6JzCJ7FGcqyNic8Mjs5ZSuMqo1quPzGxw6jEpQPE8wj0Akg6X9MmIOLyhkVnLmTa5nWmT2325qVkLq9h8JOndku6X9Iyk76dLUTvJekj95sCFaK3GCcGsdVU7p/BVYCawG7AAWAZ8LyLeEhELByI4MzMbWNWajyIibk7vF0laHxEXDUBMZmbWJNWSwihJ03PDyg/7aMHMbOiplhR+CRxTYTiAHpOCpCOAi4ARwLcjYpsntkk6EfhcmufvIuKfaorczMz6XbXnKXygLzOWNAK4FDgcWAvcIWlxerxnYZyJwGxgSkQ8KWn3vizTzMz6ppab13rrQGBNRDwYES8A1wDHlYzzYeDSiHgSICIeb2A8ZmbWg0YmhXbgsdzw2lSW93rg9ZJ+I2lZam7ahqSZkjolda5fv75B4ZqZWSOTgsqUlT68YTtgInAIcDLwbUmjtpko4vKI6IiIjjFjxvR7oGZmlql289pbJb0mN/x+ST+WdLGkXWuY91pgr9zwWGBdmXF+HBGbI+IhYDVZkjAzsyaodqRwGfACgKS/J7uT+SqyHlIvr2HedwATJU2Q9HLgJLKO9fIWAe9KyxhN1pz0YD0rYGZm/afaJakjIuKJ9H4GcHlE/BD4oaS7eppxRLwo6UyyB/SMAK6IiHsknQ90RsTiVPcPku4le0bDrIjY2JcVMjOz3quaFCRtlzrDO5Ssy4tapiuKiOuB60vKPpN7H2Rdc59Tc8RmZtYw1X7c5wG/lLQB6AZuAZD0OvyQHTOzIanazWtflHQTsAdwQ9qrh+w8xMcGIjgzMxtYVZuBImKZpH2BoyQB3BcRdw9IZGZmNuAqJgVJOwM/JrusdCXZfQf7SnoUOC4i/jwwIZqZ2UCpdknqF4BOYGJEvCcippHdQ3AH8MWBCM7MzAZWteajw4D9IuKlQkFEvCTp34BVDY/MzMwGXLUjhRfS5ahbSWXPNy4kMzNrlmpHCjtImsy2fRgJ2L5xIZmZWbNUSwp/Ar5Wpc7MzIaYavcpHDKAcZiZ2SBQ7ZLU6SVFAWwA7oqIpxsalZmZNUW15qNjypTtCuwn6fSIWNqgmMzMrEnqfkazpL2Ba4G3NSooMzNrjrqfvBYRjwAjGxCLmZk1Wd1JQdIkfJ+CmdmQVO1E80/Y9pnKu5L1mvq+RgZlZmbNUe1E81dKhgPYCDwQES80LiQzM2uWaieafwkg6WzguohYO2BRmZlZU9RyTuFVwBJJt0j6qKRXNzooMzNrjh6TQkR8PiL2AT4K7En2iM7/aXhkZmY24Oq5+uhxsj6PNgK7NyYcMzNrph6TgqR/kXQzcBMwGvhwROxXy8wlHSFptaQ1ks6rMt7xkkJSR62Bm5lZ/6v6jOZkb+ATEXFXPTOWNAK4FDgcWAvcIWlxRNxbMt5OwMeB2+uZv5mZ9b9azimcV29CSA4E1kTEg+kS1muA48qM9wXgy8BferEMMzPrR3Xf0VyHduCx3PDaVFaUHuKzV0T8tNqMJM2U1Cmpc/369f0f6QC78Mb7e1VnZtZojUwKpU9sg9wd0pJeBlwInNvTjCLi8ojoiIiOMWPG9GOIzXHRTQ+waEUXU+YsZcJ5P2PKnKUsWtFVrDMza5Zazin01lpgr9zwWGBdbngn4E3AzZIAXgMslnRsRHQ2MK5BYfbCVXRv3gJA16ZuZi9c1eSIzMwae6RwBzBR0gRJLwdOAhYXKiPiqYgYHRHjI2I8sAwYFgkBKCaE/PAnF6xsUjRmZpmGJYWIeBE4E1gC3AdcGxH3SDpf0rGNWm4re2HLS80OwcyGuUY2HxER1wPXl5R9psK4hzQyllbQPqqNrk3dzQ7DzIaxRjYfWRVtI0dsMzxr6qQmRWNmlnFSaJILpu9L+6g2RHaEcMH0fZk2ub3H6czMGqmhzUdW3lmHTmTa5PaySeCsQyc2ISIzs4wiSh+uNrh1dHREZ+ewuEDJzKzfSFoeET32L+fmIzMzK3JSMDOzIicFMzMrclIwM7MiJwUzMytyUjAzsyInBTMzK3JSMDOzIicFMzMrclIwM7MiJwUzMytyUjAzsyInBTMzK3JSMDOzIicFMzMrclIwM7MiJwUzMytqaFKQdISk1ZLWSDqvTP05ku6VtFLSTZL2bmQ8ZmZWXcOSgqQRwKXAkcAbgZMlvbFktBVAR0TsBywAvtyoeABmXHZbI2dvZtbyGnmkcCCwJiIejIgXgGuA4/IjRMQvIuK5NLgMGNuIQBat6GLKnKXc/tATTJmzlEUruhqxGDOzltfIpNAOPJYbXpvKKjkd+Hm5CkkzJXVK6ly/fn1dQSxa0cXshavo2tQNQNembmYvXOXEYGZWRiOTgsqURdkRpfcBHcDccvURcXlEdEREx5gxY+oKYu6S1XRv3rJVWffmLcxdsrqu+ZiZDQfbNXDea4G9csNjgXWlI0k6DPg08M6IeL6/g1iXjhBqLTczG84aeaRwBzBR0gRJLwdOAhbnR5A0GbgMODYiHm9EEHuOaqur3MxsOGtYUoiIF4EzgSXAfcC1EXGPpPMlHZtGmwu8ErhO0l2SFleYXa/NmjqJtpEjtiprGzmCWVMn9feizMxaXiObj4iI64HrS8o+k3t/WCOXDzBtcnZue+6S1XRt6qZ9VBuzpk4qlpuZ2V81NCkMFtMmtzNtcjszLruN+Wcc1OxwzMwGrWHVzYUTgplZdcMqKZiZWXVOCmZmVuSkYGZmRU4KZmZW5KRgZmZFTgpmZlbkpGBmZkVOCmZmVuSkYGZmRU4KZmZW5KRgZmZFTgpmZlbkpGBmZkVOCmZmVuSkYGZmRU4KZmZW5KRgZmZFTgpmZlbkpFCjGZfdNqDLu/DG+8u+H0iV1rme2C688f5+i7/SvPJl5WLuz+1XGsNAfy8qxVHvdDMuu61Psfdm2lqmqWe9+vO71QoGan23a+TMJR0BXASMAL4dEXNK6rcHrgLeAmwEZkTEw42MqV6LVnQxd8lqujZ1M2XOUmZNncS0ye0NX+5FNz3AguVrWbepmwAmjN5xQJYLPa/zRTc9wNmHv774fsLoHfnc4nvY1L0ZgF1eMZLPHrMP0ya3c9FNDwAUx+9rPLDttiiNYfx5P9smhr4sv1wMG599nl/8fv2Afy8KsRS264Lla2tedn66ggM+fwOfO3afmmPvzf9DLdP09Bn3dtyhYKDXt2FJQdII4FLgcGAtcIekxRFxb26004EnI+J1kk4CvgTMaFRM9Vq0oovZC1fRvXkLAF2bupm9cBVAQz+URSu6issrGIjlFpZd7zrPuu53bH4pisNPPreZWQt+15B4oPy2GOgYvr/s0eL7gfpe5GOpd9mLVnQx67ptt8em7s3F8lp+3Ov9btQyTa2fcb3jDgXNWN9GNh8dCKyJiAcj4gXgGuC4knGOA76b3i8ADpWkBsZUl7lLVm/1YQB0b97C3CWrG77cUgOx3MKya1nnfPND/se4YPOW4Oz5dw1YPJVi+OSClQ2JodRg+3zKTVduG0G27WqJvTfLrmWaeubbrP/JZmnG+jYyKbQDj+WG16aysuNExIvAU8BupTOSNFNSp6TO9evXNyjcba3L7anXUt7qy+3vZZf/CapPX+N5YctLDYuht+P1RW+3R1/re7vsWqapZ77N/N9ohmasbyOTQrk9/tLfiVrGISIuj4iOiOgYM2ZMvwRXiz1HtdVV3urLrWfZ8884iPlnHFR1Xu39EG9ft0UjY+jteH3R2+3R1/reLruWaeqZbzP/N5qhGevbyKSwFtgrNzwWWFdpHEnbATsDTzQwprrMmjqJtpEjtiprGzmCWVMnNXy5pQZiuYVl17vOI1+2bW4fOUL9Em+t8Qx0DKUG8+dTmK7cNoJs29USe2+WXcs09cy3Wf+TzdKM9W1kUrgDmChpgqSXAycBi0vGWQycmt4fDyyNiP5odegX0ya3c8H0fYt7m+2j2rhg+r4NP6FVmH/7qLbiodRALLew7HrXee4J+zOqbWRxeJdXjGTu8fv3S7yl8UD5bTHQMbzv7eMG/HuRj6Wg1mVPm9zO3BP236Z8VNtI5p5Q23bqzXejlmlq/YzrHXcoaMr6RkTDXsBRwP3AH4BPp7LzgWPT+x2A64A1wG+B1/Y0z7e85S3RDCd+69YBXd7Xblhd9v1AqrTO9cT2tRtW91v8leaVLysXc39uv9IYBvp7USmOeqc78Vu39in23kxbyzT1rFd/frdaQV/XF+iMGn63FYNnx7wmHR0d0dnZ2ewwzMxaiqTlEdHR03i+o9nMzIqcFMzMrMhJwczMipwUzMysqOVONEtaDzwyQIsbDWwYoGX1p1aMuxVjhtaMuxVjBsfdV3tHRI93/7ZcUhhIkjprOVs/2LRi3K0YM7Rm3K0YMzjugeLmIzMzK3JSMDOzIieF6i5vdgC91Ipxt2LM0Jpxt2LM4LgHhM8pmJlZkY8UzMysyEnBzMyKhmVSkHSEpNWS1kg6r0wOEQgNAAAH5ElEQVT9OZLulbRS0k2S9s7VbZF0V3qVdgXe7LhPk7Q+F9+HcnWnSnogvU4tnbbJcV+Yi/l+SZtydU3Z3pKukPS4pLsr1EvSxWmdVkp6c66uKdu6hphPSbGulHSrpP1zdQ9LWpW284D2OFlD3IdIeir3PfhMrq7qd6uRaoh7Vi7mu9N3eddU17Tt3aNaulIdSi9gBFlX3q8FXg78DnhjyTjvAl6R3v8LMD9X98wgjvs04JIy0+4KPJj+7pLe7zJY4i4Z/2PAFYNge/898Gbg7gr1RwE/J3t64NuB2wfBtu4p5r8rxAIcWYg5DT8MjB6k2/oQ4Kd9/W4NdNwl4x5D9ryYpm/vnl7D8UjhQGBNRDwYES8A1wDH5UeIiF9ExHNpcBnZU+Oarce4q5gK3BgRT0TEk8CNwBENirNUvXGfDMwbkMiqiIhfUf0pgMcBV0VmGTBK0h40cVv3FHNE3JpigsHzva5lW1fSl/+JPqsz7kHxva7FcEwK7cBjueG1qayS08n2CAt2kNQpaZmkaY0IsIJa435vah5YIKnwONR617k/1bzs1Ew3AViaK27W9u5JpfVq5rauR+n3OoAbJC2XNLNJMVVzkKTfSfq5pH1SWUtsa0mvINsx+GGueNBu7+2aHUATlHtQbdnrciW9D+gA3pkrHhcR6yS9FlgqaVVE/KEBcW4TTpmy0rh/AsyLiOclfQT4LvDuGqdtlHqWfRKwICK25Mqatb17Umm9mrmtayLpXWRJ4eBc8ZS0nXcHbpT0+7QnPBjcSdZvzzOSjgIWARNpgW2dHAP8JiLyRxWDdnsPxyOFtcBeueGxwLrSkSQdBnya7NGhzxfKI2Jd+vsgcDMwuZHB5vQYd0RszMX6X8Bbap22gepZ9kmUHGI3cXv3pNJ6NXNb90jSfsC3geMiYmOhPLedHwd+RNY0MyhExJ8j4pn0/npgpKTRDPJtnVPtez3otnfTT2oM9Ivs6OhBsmaKwsmpfUrGmUx2AmtiSfkuwPbp/WjgAQboxFaNce+Re/8eYFl6vyvwUIp/l/R+18ESdxpvEtnJNw2G7Z2WOZ7KJz//ka1PNP+22du6hpjHkT0P/e9KyncEdsq9vxU4YqBiriHu1xS+F2Q/no+m7V7Td6tZcaf6ncnOO+w4mLZ3tdewaz6KiBclnQksIbt64YqIuEfS+WQPtl4MzAVeCVwnCeDRiDgW+FvgMkkvkR1lzYmIewdR3B+XdCzwItkX8bQ07ROSvgDckWZ3fmx9KNvsuCE7EXdNpP+UpGnbW9I8sqteRktaC3wWGJnW6VvA9WRXIK0BngM+kOqatq1riPkzwG7AN9L3+sXIeu98NfCjVLYdcHVE/PdAxFxj3McD/yLpRaAbOCl9T8p+twZR3JDtnN0QEc/mJm3q9u6Ju7kwM7Oi4XhOwczMKnBSMDOzIicFMzMrclIwM7MiJwUzMytyUrCWkesx9Z7U5cE5kl6W6kp70rwr3YCIpGfS3/GSIl0yWpjnaEmbJV2SK5sp6ffp9VtJB+fqjpa0Ii3/XklnlIkz31vt7yWd3Yt1fTjdoFVXvaRjC72FShoj6fYU7zsk/Vu9cdjwM+zuU7CW1h0RBwCk7gGuJrs56LOp/paIOLqHeTwIHA38nzR8AlC8tl3S0cAZwMERsUFZl9iLJB0IbCR7tOKBEbFW0vZkNy+VMz8izpS0G7Ba0oKIeKzCuP0m3fdRuPfjUOD3EXEqgKSfA//Z6BistflIwVpSZN0DzATOVLoLqEbdwH2SOtLwDODaXP2ngFkRsSEt506yPqQ+CuxEtiO1MdU9HxGre4hzI9kNbntAce/9h5LuSK8pqXw3STekvfrLSP36SNpR0s/SkcndkmbkZv8xSXcq65f/DWn80yRdIukA4MvAUemI5UtAW3r/gzq2lw0zTgrWsiLrD+llwO6p6B0lzUd/U2HSa4CTJI0FtrB1fzn7AMtLxu8k6z7hCbK98EckzVP20Jqq/0OSxgE7ACtT0UXAhRHxVuC9ZP0QQXa08+uImJyWMS6VHwGsi4j9I+JNQP7O1w0R8Wbgm8C/5pcbEXeR3cE8PyIOiIhPkY60IuKUajHb8ObmI2t1+aOEWpqPIPth/QLwv8D8GpcRABHxIUn7AoeR/RAfTupOpMSM1BvpJODDEfGXVH4Y8Mbcwc2rJO1E9sCW6WkZP5NUeO7BKuAraU//pxFxS24ZC9Pf5YVpzfrKRwrWspR1p70FeLye6SJ7IMty4Fy27uMe4F7+2rtswZtTeWH6VRFxIVlCeG+FxcyPiH2AdwBflfSaVP4y4KC0x35ARLRHxNOFWZeJ9f4UzyrgAuUeRQkUesTdgnfwrJ84KVhLkjQG+BbZ40d704HXV4FPRa776OTLwJfSCWJS2/xpZJ3IvVLSIblxDwAeqbaQiLgN+B5wViq6ATgztx4HpLe/Ak5JZUeS9bCKpD2B5yLi+8BXyBJUb22WNLIP09sw4L0LayVtku4i64nyRbIf26/l6t+R6gv+IyIWlJtR6k1zmx41I2KxpHbgVkkBPA28LyL+mJp5PplOBHcDz1K+6ajUl4A7Jf0n8HHgUkkryf7/fgV8BPg8ME/SncAvybqHBtgXmKusp9jNZM8M763LgZWS7vR5BavEvaSamVmRm4/MzKzIScHMzIqcFMzMrMhJwczMipwUzMysyEnBzMyKnBTMzKzo/wOB9n44/w+qfgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#vUDS z at 0 indicates that the galaxy is not present in the vUDS catalogue\n",
+    "plt.errorbar(y = T_final[\"z_spec\"], x = T[\"ZTRUE\"], xerr = T[\"ZERR\"], fmt = 'o', capsize = 4)\n",
+    "plt.title(\"vUDS Redshift vs. DEIMOS Redshift\")\n",
+    "plt.xlabel(\"DEIMOS Redshift\")\n",
+    "plt.ylabel(\"vUDS Redshift\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0, 0.5, 'DEIMOS redshift - vUDS redshift')"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZ8AAAEWCAYAAAC5XZqEAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3Xm8HFWZ//HPlxAgyBIgAUlYgoIgiBK44Kio7NsAiYgC/pDAoKAjIi6MICqLOGwqyuAMIqAsA2GPAdEom44KyA1bCBiJrEkQEkIIS1gSnt8f51xSafr27Xu7u+72fb9e93W7qk5XPdVVXU+dqtOnFBGYmZmVabneDsDMzAYfJx8zMyudk4+ZmZXOycfMzErn5GNmZqVz8jEzs9IN2OQj6TxJ3ykMf1HSM5JekrSWpI9IeiQPj+/NWHuqch2tcZLGSApJy/d2LGWR9LikXbooU/NzkfQtSRcUhj8h6an8/Rrb7Jit+yTtIGlWHeVOknRZjenTJe2QX0vSLyQ9L+mv3QooIvrdH/A4sAh4EVgA/AX4ArBcJ+WH5vIfKIy7BfhKb69LL36GtwOv5s9wITAVOA5YsVDmJOAN4KXC34LC9AA2LpQN4OiK5RyTx59UGDcc+B/gn8ArwDTgsIr3bZ+36wvAfODPwLYlfC5jcrzL93C/3KVi3KHAnyrm3fFZPgPcCOzam+teLe5GPxfgH8C47iyjhduyq8+743hS3M/Prdx+hbKvAyMq5nFfXtaYwrgPA7fm79gLwA3A5hXv+xbwWF7mLODKFn4eOwCz6ih3EnBZnfP8aI77Hd1ZRkT065rPPhGxKrAhcDrwTeDCTsquA6wETC+M27BiuG4D6Kz4qPwZrgt8HTgQuEmSCmWujIhVCn/Da8zv78CEinGH5PEASFoBuJn0+X8IWB04Fjhd0tdymdVIB4n/AtYERgMnA6/1eE37luERsQrwAeD3wPWSDoXG170P7Zs9/n61QKefd8E+Ffv5UTXm9xhwUMeApC2BYcUCkj4E/A74FTAK2Ai4H/izpHflMhOAz5KS8ipAG+mkuEt9bDs/HhEvd/udZZ6JNDGDP87bzzC3A94E3peHfwmcCrwHeJmlZ0C3ks7K3mTp2c6KpIPghcDTwOz83iGFs58/A2eTzkRPzeP/DXgYeB6YAmxYiCdItbFH8vSfAipM/3x+74vAQ8DWefwo4FpgLmknP7rG5/DLQiw7kM5Avg48m9fjsBrvvR34XMW4DUg1kb3rOQPi7TWfy/I6bZHHbZGHLyPXfIDDc3zvqJjXAXlbrEb6Ei7obLlV4tgOuINUC34aOBdYoZ5tAQwBfgDMAx4FvkQnZ/ikmuE1FeN+ApxTY788lLfXfJavKPMN0ln5cj1Y95OAa/JnvBD4XJ7PcaT9/DngKmDNwns+CzyRp51QjDt/lu15Xs8AP6qIfQLwZP68TqiI4zLSd+mlXPblHMOlLPt9+48q6/Fwx36Xh5fPy9iadOJ4WY53AXA3sE4dn02Xn3dn263a9iuU/TZwd2HcD/Ln+FbNB/g/4L+rzO83wCX59bnAj7t53Psm8ADpZGR5ahwvSAnxl6R9/iHSSd6swvRvko51LwIzgJ0L2/Iq4JI8bTrQVhHHLqTv8qvAkrxdz8rb+E2W1iBHdbY+/bnms4yI+Cvp4PvRivF/Jx0EIZ0B7RQR7yZ9gTrOdl4DLgYWAxsDY4HdSF/kDh8kHZzWBr6f7xN9C9gPGEna2a6oCGtvYFvSGdengd0BJH2KtIEPIR1s9wWek7QcqWp+P+mMd2fgGEm71/kxvJOUREeTdoyfSlqjzvcSEU+SDjwf7apsDZeS1gvSgeqSium7Ar+Jt58pXUs6yHyIVFNaIuliSXvWsQ5LgK8CI/L7dwb+vaJM1W1BOgnYm7TN24D9ayznCmCvXDtB0pA8r8u7iK8r15H2q03p/roDjCMloOHA/wJHA+OBj5MOTh0JF0mbky55fjZPWwtYrzCvnwA/iYjVgHeTDkJF2+c4dwa+K+m9xYkR8Vqks3hIl7nfHRGfZdnv25lV1uEKCrUJ0vaZFxH3kPaj1YH1c7xfIB3keqr4effEncBqkt6b94EDSMkRAEkrky65XV3lvVeRvgMd8zlE0rGS2vK8unIQ8K+kbf0mtY8XJ5K24btJn+dbVyUkbQocRbqcu2qe/nhhOfsCE/NyJpMS5TIi4kLStrgjb9djgT2BObG0BjmnsxUZMMknm0O6VNEtktYhfWjHRMTLEfEsqZZzYHHeEfFfEbE4IhYBRwKnRcTDEbEY+E9gK0kbFt5zekQsyAf124Ct8vjPAWdGxN2RzIyIJ0gHx5ERcUpEvB4RjwI/r4ijljeAUyLijYi4iXTm0d0vWOVn+GlJCwp/t3Xx/suAgyQNzXFX3rgcQaqdLCN/hvNI19IXkg5yQVr/uZIm5+30NhExNSLuzNvmceBnpANvUWfb4tOks8+nImI+cFpnK5a30T2kAzvATsArEXFnZ++pU8cXdM3urnt2R0RMiog3C/vmCRExK59YnQTsny/V7A/cGBF/zNO+QzqIdXgD2FjSiIh4qcq6nRwRiyLiftJB7wONrfpbLgf2zQdugM+wNKm/QUo6G0fEkry9FzawrLc+78K4SRX7+ee7mEfHSdauwN9INYgOa5KOrW/bz/O4EQARcRnwZdKB/w/As5KO62K55+R9dRFdHy8+DXw/IuZHxFPAOYX5LCHVUjeXNDQiHo+IfxSm/ykiboqIJXldm7Wd3zLQks9o0mWx7tqQ1Cjh6Y6dj3QAW7tQ5qkq7/lJofx8QDmGDv8svH4F6DgjXJ90OaJaHKOKXwJS7arWgafouXwQr7bMelV+hldFxPDC34613pwP7jNJyfiRvNMXzSPdY1pGPjCOyNPJSf3QiFgPeB/pLP3H1ZYp6T2SbpT0T0kL87JHVBTrbFuMYtlt+0St9SMdEDvO0IsHSEg156EV5YeSDp61dOwz86F7655V2zevL+xDD5MONutQsb65Bvpc4b2Hky5V/03S3ZL2rph3Z59jQyJiZo5zn5yA9mXpZ3sp6bL2RElzJJ2ZT256apnPOxtfsZ//vIt5XEra/ofy9tr986SE/rb9PI+b1zEQEf8bEbuQahhfAE7p4kpHcVt3dbzodN/On/cxpBOTZyVNlDSqULZyO6/U7PtMAyb5SNqWtFP9qQdvf4p0DXVEYedbLSK2KJSp7P77KeDIih12WET8pc7lvbuT8Y9VzHPViNirB+vUbZLWB7YhXUJsxCWke0+VX0pIjQ32lPSOivGfJG2Dt9UiIuJvpGvX7+tkef9DOvvcJF8u+hbpRKAeT5NOBjps0EX5q4EdJK0HfIJlk8+TpPsMRRvRdUL7BOk+2IzKCXWsO1TfN/es2I9WiojZVKxvPtCvVVjeIxFxEOnE6wzgmirbqifq6T6/49LbOOChfIAk1+RPjojNSZez9mbppd2e6PTzrleuBT8G7EW6jFec9jLpHuSnqrz101RpVJDX8WrS/Zx6t3VXx4ua+3ZEXB4R25OSWJC2d6Pq2c7AAEg+klbLZ2cTSTfHp3V3HhHxNKllyg/z/JaT9G5JlZduis4Djpe0RY5j9Xwvpx4XAN+QtE1uJ79xvlz3V2ChpG9KGiZpiKT35cTaMpJWzuv6qxzDTQ3O8krSPbPK+wWQzhhnAVcr/XZkaD7TO4fUKOEFSZtJ+no+wHckxYOokpiyVUk3yF+StBnwxW7EehVwtKT18v2Vmpc9ImIuqbHGL0hf/IcLk68kXXPfLG/XNlKjlInV5iVpHUlHka7NHx8Rb/Zg3as5j3RfcsM8j5GSxuVp1wB7S9peqeXhKRSOA5IOljQyIt4k3dyHVGtq1DPAu7ooM5G033yRQlKXtKOkLfM9kYWkmmS3Y6r2eXd3HhUOB3aK6i29jgMmSDpa0qqS1pB0Kume5Mk5nkMl/WuevpykPUn3p++qc/ldHS+uIh2j1sj705c73ihpU0k7SVqR1GhgEc3bzmtJWr2rgv05+dwg6UVS9j8B+BFwWAPzOwRYgdQq5HnSl7RatRmAiLiedKYwMV/qeZB036hL+Qzn+6Qv2IvAJNL1/iXAPqT7EY+RqucXkG62tsK5+TN8hnRZ51pgj4ov5QFKPxQs/q1ddW5Zvidwc74uXTntNVJLmadIX7KFpG13QkSclYu9SGrgcZekl0kH3gdJtalqvkG6BPIi6Zr3lfWsfPZz0iWd+0n3c66rXRxI220X3t7Q4OekpHQD6Xcdl5DW67cV5Rbk9ZpGOnP+VERclKd1d92r+QnpJvHv8va9M8+TiJhOatF3OenM+HnSyUCHPYDpkl7K8zkwIl7txrI7cxrw7Xx56BvVCuSTwDtItZviNnwn6fu4kHRp7g/ke4lKP7Q+r4tl1/q8O9xQsY9f39UKRcQ/IqK9k2l/It3L2Y/0OT9BatSyfUQ8kostJNXSnyQl+jOBL+b3dqmO48XJebmPkU6uLy28fUXST1TmkS6xrZ1jaUiuqV8BPJq39ajOynY0NzUzMytNf675mJlZP+XkY2ZmpXPyMTOz0jn5mJlZ6fpK53SlGDFiRIwZM6a3wzAz61emTp06LyJGNnOegyr5jBkzhvb2qi0jzcysE5K6+qF0t/mym5mZlc7Jx8zMSufkY2ZmpXPyMTOz0jn5mJlZ6Zx8zMysdE4+ZmZWOicfMzMrnZOPmZmVzsnHzMxK5+RjZmalc/IxM7PSOfmYmVnpnHzMzKx0Tj5mZlY6Jx8zMyudk4+ZmZXOycfMzErn5GNmZqXr1eQjaQ9JMyTNlHRclekrSroyT79L0pg8fjtJ9+W/+yV9ouzYzcys53ot+UgaAvwU2BPYHDhI0uYVxQ4Hno+IjYGzgTPy+AeBtojYCtgD+Jmk5cuJ3MzMGtWbNZ/tgJkR8WhEvA5MBMZVlBkHXJxfXwPsLEkR8UpELM7jVwKilIjNzKwpejP5jAaeKgzPyuOqlsnJ5gVgLQBJH5Q0HZgGfKGQjJYh6QhJ7ZLa586d2+RVMDOznujN5KMq4yprMJ2WiYi7ImILYFvgeEkrVVtIRJwfEW0R0TZy5MiGAjYzs+bozeQzC1i/MLweMKezMvmezurA/GKBiHgYeBl4X8siNTOzpurN5HM3sImkjSStABwITK4oMxmYkF/vD9waEZHfszyApA2BTYHHywnbzMwa1WstxCJisaSjgCnAEOCiiJgu6RSgPSImAxcCl0qaSarxHJjfvj1wnKQ3gDeBf4+IeeWvhZmZ9YQiBk9Dsba2tmhvb+/tMMzM+hVJUyOirZnzdA8HZmZWui6Tj6Rb6hlnZmZWr07v+eSmyysDIyStwdJmz6sBo0qIzczMBqhaDQ6OBI4hJZqpLE0+C0nd4piZmfVIreQzJyI2knR0RJxTWkRmZjbg1brnc3z+f2gJcZiZ2SBSq+bznKTbgI0kVf74k4jYt3VhmZnZQFYr+fwrsDVwKfDDcsIxM7PBoNPkkx9zcKekD0eEu4M2M7OmqdXU+scRcQxwkaS3dYPgy25mZtZTtS67XZr//6CMQMzMbPCoddltav7/h/LCMTOzwaDLXq0lfQQ4CdgwlxcQEfGu1oZmZmYDVT2PVLgQ+Cqpl4MlrQ3HzMwGg3qSzwsR8ZuWR2JmZoNGrdZuW+eXt0k6C7gOeK1jekTc0+LYzMxsgKpV86n8YWnxQUIB7NT8cMzMbDCo1dptxzIDMTOzwaOeh8l9RdJqSi6QdI+k3coIzszMBqZ6HqP9bxGxENgNWBs4DDi9pVGZmdmAVk/y6XiI3F7ALyLi/sI4MzOzbqsn+UyV9DtS8pkiaVXgzdaGZWZmA1k9v/M5HNgKeDQiXpG0FunSm5mZWY/U8zufDu+SfLXNzMwaV8/vfFYCtgEeIN3reT9wF7B9a0MzM+ufJt07m7OmzGDOgkWMGj6MY3fflPFjR/d2WH1Kp/d8ImLH/FufJ4BtIqItIrYBxgIzm7FwSXtImiFppqTjqkxfUdKVefpdksbk8btKmippWv7vH7yaWZ8w6d7ZHH/dNGYvWEQAsxcs4vjrpjHp3tm9HVqfUk+Dg80iYlrHQEQ8SLoH1BBJQ4CfAnsCmwMHSdq8otjhwPMRsTFwNnBGHj8P2CcitgQmsPTZQ2ZmveqsKTNY9MayfTAvemMJZ02Z0UsR9U31JJ+H849Ld5D0cUk/Bx5uwrK3A2ZGxKP5kd0TgXEVZcYBF+fX1wA7S1JE3BsRc/L46cBKklZsQkxmZg2Zs2BRt8YPVvUkn8NIB/ivAMcAD9Gc1m6jgacKw7PyuKplImIx8AKwVkWZTwL3RsRrVCHpCEntktrnzp3bhLDNzDo3aviwbo0frLpMPhHxKnAecFxEfCIizs7jGlWt6Vx0p4ykLUiX4o7sbCERcX6+X9U2cuTIHgVqZlavY3fflGFDhywzbtjQIRy7+6a9FFHfVE/fbvsC9wG/zcNbSZrchGXPAtYvDK8HzOmsjKTlgdWB+Xl4PeB64JCI+EcT4jEza9j4saM5bb8tGT18GAJGDx/Gaftt6dZuFer5kemJpPsztwNExH0drc4adDewiaSNgNnAgcBnKspMJjUouAPYH7g1IkLScODXwPER8ecmxGJm1jTjx452sulCPfd8FkfEC81ecL6HcxQwhdSA4aqImC7plFzbgvQI77UkzQS+BnQ0xz4K2Bj4jqT78t/azY7RzMxao56az4OSPgMMkbQJcDTwl2YsPCJuAm6qGPfdwutXgU9Ved+pwKnNiMHMzMpXT83ny8AWpEdoX05qcXZMK4MyM7OBrWbNJ/8Q9OSIOBY4oZyQzMxsoKtZ84mIJaR+3czMzJqmnns+9+am1VcDL3eMjIjrWhaVmZkNaPUknzWB54Bi550BOPmYmVmPdJl8IsIPjjMzs6aqp+ZjA5SfOWJmvcXJZ5DqeOZIR9fvHc8cAZyAzKzlnHwGqVrPHHHyMevf+sNVjU6bWkvaR9KGheHvSrpf0uTcH5v1Y37miNnA1F+epFrrdz7fB+YCSNobOBj4N1Jnn+e1PjRrJT9zxGxg6i9PUq2VfCIiXsmv9wMujIipEXEB4Afj9HN+5ojZwNRfrmrUSj6StIqk5YCdgVsK01ZqbVjWan7miNnA1F+uatRqcPBj0kPkFgIPR0Q7gKSxwNMlxGYt5meOmA08x+6+6TItWaFvXtXoNPlExEWSpgBrA/cXJv0T8A9Pzcz6oI4Tyr7e2q2rptbPAFsDu0iC9NC33+YHwZmZWR/UH65q1GpqPQqYDnwdGAWMBo4FpudpZmZmPVKr5vOfwP9ExI+LIyUdDZwGTGhlYGZmNnDVSj7/EhGHVo6MiHMk9a0G42Zm1q/Uampdq1H4KzWmmZmZ1VSr5rO6pP2qjBewWoviMTOzQaBW8vkDsE8n0/7YgljMzGyQqPU7H/+Wx8zMWqLT5CPpaxWjApgH/CkiHmtpVGZmNqDVanCwasXfakAb8BtJB5YQm5mZDVC1LrudXG28pDWBm4GJjS5c0h7AT4AhwAURcXrF9BWBS4BtgOeAAyLicUlrAdcA2wK/jIijGo3FzMzKU6vmU1VEzCe1eGuIpCHAT4E9gc2BgyRtXlHscOD5iNgYOBs4I49/FfgO8I1G4zAzs/J1O/lI2gl4vgnL3g6YGRGPRsTrpJrUuIoy44CL8+trgJ0lKSJejog/kZKQmZn1M7UaHEwjNTIoWhOYAxzShGWPBp4qDM8CPthZmYhYLOkFYC1Sw4e6SDoCOAJggw02aCReMzNrklq/89m7YjiA5yLi5SYtu9qlu8pkV0+ZmiLifOB8gLa2tm6918zMWqPTy24R8UREPAF8DRgVEU82MfFAqumsXxhej1SrqlpG0vLA6sD8JsZgZma9oJ57PvcA35E0U9JZktqatOy7gU0kbSRpBeBAYHJFmcks7T17f+DWiHDtxcysn+vqYXJExMXAxbmJ9SeBMyRtEBGbNLLgfA/nKGAKqan1RRExXdIpQHtETAYuBC6VNJNU43nr90WSHif99mgFSeOB3SLioUZiMjOzcnSZfAo2BjYDxgBNOchHxE3ATRXjvlt4/SrwqU7eO6YZMZiZWfm6vOwm6QxJjwCnAA8C20REZx2OmpmZdamems9jwIciou7mzWZmZrXUc8/nvDICMTOzwaPbPRyYmZk1ysnHzMxK163kk7uqMTMza0h3az5faEkUZmY2qHQ3+TT8KAUzM7PuJh//vsfMzBrWreQTEbNaFYiZmQ0ebu1mZmal6/JHppJWjIjXuhpnZjYYTLp3NmdNmcGcBYsYNXwYx+6+KePHju7tsPqderrXuQPYuo5xZmZ9SrMTxaR7Z3P8ddNY9MYSAGYvWMTx100DcALqplqP0X4n6THWwySNZWlLt9WAlUuIzcysx1qRKM6aMuOt+XVY9MYSzpoyw8mnm2rVfHYHDiU9YfSHLE0+C4FvtTYsM7PGtCJRzFmwqFvjrXO1ks/wiNhR0rcj4tTSIjIza4JWJIpRw4cxu8r7Rw0f1uN5Dla1Wrsdlv/vV0YgZmbN1FlCaCRRHLv7pgwbOmSZccOGDuHY3Tft8TwHq1rJ5+H8qOpNJT1Q+Jsm6YGS4jMz65FWJIrxY0dz2n5bMnr4MASMHj6M0/bb0vd7eqDTy24RcVBudDAF2Le8kMzMGteREJrdLHr82NFONk1Qs6l1RPwT+EBJsZiZNZUTRd9Vq6n1VRHxaUnTgChOAiIi3t/y6MzMbECqVfP5Sv6/dxmBmJnZ4FHrns/T+f8T5YVjZmaDQZcdi0raT9Ijkl6QtFDSi5IWlhGcmZkNTPX07XYmsE9EPNzqYPoydyZoZtY89TxS4ZlWJR5Je0iaIWmmpOOqTF9R0pV5+l2SxhSmHZ/Hz5C0eyvi69DRR9TsBYsIlvYRNene2a1crJnZgFWrtVtHzwbtkq4EJgFvPUYhIq5rZMGShgA/BXYFZgF3S5ocEQ8Vih0OPB8RG0s6EDgDOEDS5sCBwBbAKOBmSe+JiGU7cmoSdyZoZtZctS67FR+Z/QqwW2E4gIaSD7AdMDMiHgWQNBEYBxSTzzjgpPz6GuBcScrjJ+ZnCj0maWae3x0NxlSVOxO0nvClWrPO1Wrtdlhn05pkNPBUYXgW8MHOykTEYkkvAGvl8XdWvLfqt1rSEcARABtssEGPAnVngtZdfu6LdcdgPFGpp7XbmZJWkzRU0i2S5kk6uAnLVpVxUWeZet6bRkacHxFtEdE2cuTIboaYuDNB665al2rNigbrPeV6GhzsFhELST82nQW8Bzi2CcueBaxfGF4PmNNZGUnLA6sD8+t8b9O4M0HrLl+qtXoN1hOVeppaD83/9wKuiIj56bZLw+4GNpG0ETCb1IDgMxVlJgMTSPdy9gdujYiQNBm4XNKPSA0ONgH+2oygOuM+oqw7fKnW6jVYT1TqqfncIOlvQBtwi6SRwKuNLjgiFgNHkXrNfhi4KiKmSzpFUkcv2hcCa+UGBV8DjsvvnQ5cRWqc8FvgS61q6WbWE75Ua/VqxXOH+gNFVL1VsmwhaQ1gYUQskfQOYNXc43W/0tbWFu3t7b0dhg0Sg/EmsnVfZeMUSCcqfenSvqSpEdHWzHnW8zuf4rjiYKNNrc0GNF+qtXq06rlDfV09v/NZG/gwcGse3hG4HScfM7OmGIwnKl3+zkfSjcDmHb1cS1qX1DOBmZlZj9TT4GBMR+LJniE1tzYzM+uReppa3y5pCnAF6YecBwK3tTQqMzMb0LpMPhFxlKRPAB/Lo86PiOtbG5aZmQ1k9dR8AO4BXoyImyWtLGnViHixlYGZmdnAVU/fbp8n9Sj9szxqNOnxCmZmZj1ST4ODLwEfARYCRMQjpObXZmZmPVJP8nktIl7vGMgdfHbdLYKZmVkn6kk+f5D0LWCYpF2Bq4EbWhuWmZkNZPUkn+OAucA04EjgJuDbrQzKzMwGtpqt3SQNAS6OiIOBn5cTkpmZDXQ1az75MQUjJa1QUjxmZjYI1PM7n8eBP+cHuL3cMTIiftSqoMzMbGCrJ/nMyX/LAau2NhwzMxsM6ule5+QyAjHry/xgOLPmqrd7HbNBq/JJk7MXLOL466YBOAGZ9VA9Ta3NBrWzpsxY5hHHAIveWMJZU2b0UkRm/Z+Tj1kX5ixY1K3xZta1TpOPpM9L2iS/lqRfSFoo6QFJW5cXolnvGjV8WLfGm1nXatV8vkJqZg1wEPB+YCPga8BPWhuWWd9x7O6bMmzokGXGDRs6hGN337SXIjLr/2oln8UR8UZ+vTdwSUQ8FxE3A+9ofWhmfcP4saM5bb8tGT18GAJGDx/Gaftt6cYGZg2o1drtTUnrAs8DOwPfL0zz9QYbVMaPHe1kY9ZEtZLPd4F2YAgwOSKmA0j6OPBoCbGZmdkA1ellt4i4EdgQeG9EfL4wqR04oJGFSlpT0u8lPZL/r9FJuQm5zCOSJhTGf1/SU5JeaiQOMzPrHV01tV4TOEbSNZKulnQysEpENHrQPw64JSI2AW7Jw8uQtCZwIvBBYDvgxEKSuiGPMzPrFybdO5uPnH4rGx33az5y+q1Mund2b4fUq2o1tf4IcHcevAS4LL++K09rxDjg4vz6YmB8lTK7A7+PiPkR8Tzwe2APgIi4MyKebjAGM7NSdPSSMXvBIoKlvWQM5gRU657PD4HxEXFvYdyvJF0P/IxUI+mpdTqSR0Q8LWntKmVGA08Vhmflcd0i6QjgCIANNtigB6GamTWmVi8Zg7UhS63ks1pF4gEgIu6T1GXv1pJuBt5ZZdIJdcamKuOizvcufUPE+cD5AG1tbd1+v5lZo9xLxtvVSj6StEa+5FUcuSZ1dMsTEbvUmPEzktbNtZ51gWerFJsF7FAYXg+4vavlmpn1NaOGD2N2lUQzmHvJqJVEzgZ+J+njklbNfzsAv8nTGjEZ6Gi9NgH4VZUyU4DdJK2RGxrslseZmfUr7iXj7Tqt+UTE+ZLmAN8DtsijpwOnRsQNDS73dOAqSYcDTwKfApDUBnwhIj4XEfMlfY+ljR5OiYj5udyZwGeAlSXNAi6IiJMajMnMrCU67uv4mVBLKWLw3AZpa2uL9vb23g7DzKxfkTQ1ItqaOc9Oaz6Szqn1xog4upmBmJnZ4FGrwcEXgAewpklnAAALWElEQVSBq4A5VG99ZmZm1m21ks+6pHsxBwCLgSuBaytbv5mZmXVXrb7dnouI8yJiR+BQYDgwXdJnywrOzMwGplo1HwDyU0sPAnYlNbOe2uqgzMxsYKvV4OBk0kPkHgYmAsdHxOKyAjMzs4GrVs3nO6Tn9nwg//2nJEgNDyIi3t/68MzMbCCqlXw2Ki0KMzMbVGr1cPBEmYGYmdngUeuez4tU70W647Lbai2LyszMBrRaNZ8uH5tgZmbWE7WeZLpT4fVGFdP2a2VQZmY2sNV6pMIPCq+vrZj27RbEYmZmg0St5KNOXlcbNjMzq1ut5BOdvK42bGZmVrdav/N5l6TJpFpOx2vysH8DZGZmPVYr+YwrvP5BxbTKYTMzs7rVamr9h47XkkbmcXPLCMrMzAa2Wk2tJelESfOAvwF/lzRX0nfLC8/MzAaiWg0OjgG2B7aNiLUiYg3gg8BHJH21lOjMzGxAqpV8DgEOiojHOkZExKPAwXmamZlZj9RKPkMjYl7lyHzfZ2jrQjIzs4GuVvJ5vYfTzMzMaqrV1PoDkhZWGS9gpRbFY2Zmg0CtptZDygzEzMwGj1qX3VpG0pqSfi/pkfx/jU7KTchlHpE0IY9bWdKvJf1N0nRJp5cbvZmZNapXkg9wHHBLRGwC3JKHlyFpTeBEUvPu7YATC0nqBxGxGTCW1PR7z3LCNjOzZuit5DMOuDi/vhgYX6XM7sDvI2J+RDwP/B7YIyJeiYjbACLideAeYL0SYjYzsybpreSzTkQ8DZD/r12lzGjgqcLwrDzuLZKGA/uQak9VSTpCUruk9rlz3TuQmVlfUKu1W0Mk3Qy8s8qkE+qdRZVxbz3KQdLywBXAOfnHr1VFxPnA+QBtbW1+FISZWR/QsuQTEbt0Nk3SM5LWjYinJa0LPFul2Cxgh8LwesDtheHzgUci4sdNCNfMzErUW5fdJgMT8usJwK+qlJkC7CZpjdzQYLc8DkmnAquT+p8zM7N+preSz+nArpIeAXbNw0hqk3QBQETMB74H3J3/TomI+ZLWI1262xy4R9J9kj7XGythZmY9o4jBcxukra0t2tvbezsMM7N+RdLUiGhr5jx7q+ZjZmaDmJOPmZmVzsnHzMxK5+RjZmalc/IxM7PSOfmYmVnpnHzMzKx0Tj5mZlY6Jx8zMyudk4+ZmZXOycfMzErn5GNmZqVz8jEzs9I5+ZiZWemcfMzMrHROPmZmVjonHzMzK52Tj5mZlW5QPUZb0lzgiSbPdgQwr8nz7E1en77N69O3DdT12TAiRjZzxoMq+bSCpPZmP9u8N3l9+javT9/m9amfL7uZmVnpnHzMzKx0Tj6NO7+3A2gyr0/f5vXp27w+dfI9HzMzK51rPmZmVjonHzMzK52TTx0k7SFphqSZko6rMv1rkh6S9ICkWyRt2Btx1qur9SmU219SSOrTTUfrWR9Jn87baLqky8uOsbvq2Oc2kHSbpHvzfrdXb8RZD0kXSXpW0oOdTJekc/K6PiBp67Jj7I461uf/5fV4QNJfJH2g7Bi7o6v1KZTbVtISSfs3ZcER4b8af8AQ4B/Au4AVgPuBzSvK7AisnF9/Ebiyt+NuZH1yuVWBPwJ3Am29HXeD22cT4F5gjTy8dm/H3YR1Oh/4Yn69OfB4b8ddY30+BmwNPNjJ9L2A3wAC/gW4q7djbnB9PlzY1/bs7+uTywwBbgVuAvZvxnJd8+nadsDMiHg0Il4HJgLjigUi4raIeCUP3gmsV3KM3dHl+mTfA84EXi0zuB6oZ30+D/w0Ip4HiIhnS46xu+pZpwBWy69XB+aUGF+3RMQfgfk1iowDLonkTmC4pHXLia77ulqfiPhLx75G3z8e1LN9AL4MXAs07bvj5NO10cBTheFZeVxnDiedxfVVXa6PpLHA+hFxY5mB9VA92+c9wHsk/VnSnZL2KC26nqlnnU4CDpY0i3Q2+uVyQmuJ7n7H+pO+fjzokqTRwCeA85o53+WbObMBSlXGVW2fLulgoA34eEsjakzN9ZG0HHA2cGhZATWonu2zPOnS2w6ks9D/k/S+iFjQ4th6qp51Ogj4ZUT8UNKHgEvzOr3Z+vCaru7vWH8iaUdS8tm+t2Np0I+Bb0bEEqnapuoZJ5+uzQLWLwyvR5VLHJJ2AU4APh4Rr5UUW090tT6rAu8Dbs872juByZL2jYj20qKsXz3bZxZwZ0S8ATwmaQYpGd1dTojdVs86HQ7sARARd0haidQJZF+/pFhNXd+x/kTS+4ELgD0j4rnejqdBbcDEfDwYAewlaXFETGpkpr7s1rW7gU0kbSRpBeBAYHKxQL5M9TNg335wP6Hm+kTECxExIiLGRMQY0jXrvpp4oI7tA0wiNQpB0gjSZbhHS42ye+pZpyeBnQEkvRdYCZhbapTNMxk4JLd6+xfghYh4ureD6ilJGwDXAZ+NiL/3djyNioiNCseDa4B/bzTxgGs+XYqIxZKOAqaQWnxcFBHTJZ0CtEfEZOAsYBXg6nx28GRE7NtrQddQ5/r0G3WuzxRgN0kPAUuAY/vy2Wid6/R14OeSvkq6RHVo5GZJfY2kK0iXPEfke1QnAkMBIuI80j2rvYCZwCvAYb0TaX3qWJ/vAmsB/52PB4ujD/d0Xcf6tGa5fXR/NTOzAcyX3czMrHROPmZmVjonHzMzK52Tj5mZlc7Jx8zMSufkY4NC7o33vtyr9f25J/Ll8rQdJL2Qp3f87ZKnvZT/j8k9fH+vMM8Rkt6QdG5h3BGS/pb//ipp+8K0vXMv1PfnHraPbOL6/bJWb8OdTZc0StI1heErcm/MX5V0qKRRzYrRrMi/87HBYlFEbAUgaW3gclKHnCfm6f8XEXt3MY9Hgb2B7+ThTwHTOyZK2hs4Etg+IublRwNMkrQd8BypJ+rtImKWpBWBMbUWJmn5iFjcjXXstoiYA+yfl/dO4MMRsWEevh14kH7e24D1Ta752KCTe6E4AjhK3eusahHwsJY+3+gA4KrC9G+SfsA6Ly/nHuBi4EukbouWJyUhIuK1iJhRuQBJJ0k6X9LvgEskDZF0lqS7c43kyFxOks7NNahfA2sX5nG6lj5f6geF2X9M6fkyj3bUgnKNruM5Lr8D1s41v++QulX53zw8rBufk1mXXPOxQSkiHs2X3ToO2h+VdF+hyCcj4h9V3joROFDSP0m9JcwBOi5NbQFMrSjfDkyIiPmSJgNPSLoFuBG4opOOQLch1Z4WSTqC1N3Mtrm29OecmMYCmwJbAusADwEXSVqT1APxZhERkoYX5rsuqZPLzUhd2lzDsvYFbizUEHcGvtGHu1ayfszJxwazYq2nnstuAL8lPevoGeDKOpcRABHxOUlbArsA3wB2pXrv4ZMjYlF+vRvw/sL9mtVJnaJ+jJS8lgBzJN2apy8kPYPpglwjKj4WY1JOdg9JWqeO2M1axpfdbFCS9C5SzaVbHcHmh7tNJfWtdm3F5IdItZairfP4jvdPi4izSYnnk50s5uViqMCXI2Kr/LdRRPyuY3ZV4ltMehjdtcB4UrLsUOxtvXl945v1gJOPDTqSRpIejHVuDzvj/CHp+SaVnZOeCZwhaa28nK1INZv/lrSKpB0KZbcCnqhjWVOAL0oamuf5HknvID3i/MB8T2hdlvbavQqwekTcBByTl9NTL5LuVZk1nS+72WAxLN/TGQosBi4FflSYXnnP59SIqLwnAkBETKfQyq0wfrLSUx//IilIB++DI+JpSasC/yHpZ6SGCy9T3wP7LiC1irsnN46YS6rRXA/sBEwD/g78IZdfFfiV0vN9BHy1jmV05pfAeZIWAR8qXAo0a5h7tTYzs9L5spuZmZXOycfMzErn5GNmZqVz8jEzs9I5+ZiZWemcfMzMrHROPmZmVrr/D8gCrMY7vCtyAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "diff = []\n",
+    "x_axis = []\n",
+    "err = []\n",
+    "for x in range(0, len(T_final[\"z_spec\"])):\n",
+    "    if T_final[\"z_spec\"][x] != 0:\n",
+    "        diff.append(T_final[\"ZTRUE\"][x] - T_final[\"z_spec\"][x])\n",
+    "        x_axis.append(T_final[\"ZTRUE\"][x])\n",
+    "        err.append(T_final[\"ZERR\"][x])\n",
+    "\n",
+    "plt.scatter(x_axis, diff)\n",
+    "plt.title(\"Difference in DEIMOS and vUDS redshift vs. DEIMOS redshift\")\n",
+    "plt.xlabel(\"DEIMOS redshift\")\n",
+    "plt.ylabel(\"DEIMOS redshift - vUDS redshift\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/cosmos_spec_matching.ipynb
+++ b/cosmos_spec_matching.ipynb
@@ -425,7 +425,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,

--- a/cosmos_spec_matching.ipynb
+++ b/cosmos_spec_matching.ipynb
@@ -425,7 +425,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The Galaxy_survey_lib_with_HST notebook generates the tables needed for the spec_plotting_test to plot multiple spectra from different surveys for each galaxy. The necessary inputs for the Galaxy_survey_lib_with_HST are in the SC-SN-DATA/Leah Uploads-matching spectra/galaxy inputs. I also have the vUDS spectra for the spec_plotting_test there, as well as data tables for the spec_plotting_test should the Galaxy_survey notebook not work.